### PR TITLE
Workflow cache for faster CI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -49,6 +49,13 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v3
 
+            - name: Mount bazel cache
+              uses: actions/cache@v3
+              with:
+                path: "/home/runner/.cache/bazel"
+                key: bazelcache-linux-ubuntu-build-${{ github.ref_name }}-${{ github.sha }}
+                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+
             - name: "Install dependencies"
               run: |
                   python -m pip install --upgrade pip
@@ -67,6 +74,13 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v3
 
+            - name: Mount bazel cache
+              uses: actions/cache@v3
+              with:
+                path: "/home/runner/.cache/bazel"
+                key: bazelcache-linux-ubuntu-coverage-${{ github.ref_name }}-${{ github.sha }}
+                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                
             - name: "Install dependencies"
               run: |
                   python -m pip install --upgrade pip
@@ -90,6 +104,13 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v3
 
+            - name: Mount bazel cache
+              uses: actions/cache@v3
+              with:
+                path: "/home/runner/.cache/bazel"
+                key: bazelcache-linux-ubuntu-lint-${{ github.ref_name }}-${{ github.sha }}
+                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                
             - name: "Check code formatting"
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
@@ -103,6 +124,13 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v3
 
+            - name: Mount bazel cache
+              uses: actions/cache@v3
+              with:
+                path: "/home/runner/.cache/bazel"
+                key: bazelcache-linux-ubuntu-test-${{ github.ref_name }}-${{ github.sha }}
+                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                
             - name: "Set up Python"
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -21,8 +21,8 @@ jobs:
               uses: actions/cache@v3
               with:
                 path: "/home/runner/.cache/bazel"
-                key: bazelcache-linux-pi3hat-${{ github.sha }}
-                restore-keys: bazelcache-linux-pi3hat-
+                key: bazelcache-linux-pi3hat-${{ github.ref_name }}-${{ github.sha }}
+                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
           
             - name: "Install dependencies"
               run: |

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -17,6 +17,13 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v3
 
+            - name: Mount bazel cache
+              uses: actions/cache@v3
+              with:
+                path: "/home/runner/.cache/bazel"
+                key: bazelcache-linux-pi3hat-${{ github.sha }}
+                restore-keys: bazelcache-linux-pi3hat-
+          
             - name: "Install dependencies"
               run: |
                   sudo apt install libncurses5

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -54,7 +54,7 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-build-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                restore-keys: bazelcache-linux-ubuntu-build-${{ github.ref_name }}-
 
             - name: "Install dependencies"
               run: |
@@ -79,7 +79,7 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-coverage-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                restore-keys: bazelcache-linux-ubuntu-coverage-${{ github.ref_name }}-
                 
             - name: "Install dependencies"
               run: |
@@ -109,7 +109,7 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-lint-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                restore-keys: bazelcache-linux-ubuntu-lint-${{ github.ref_name }}-
                 
             - name: "Check code formatting"
               env:
@@ -129,7 +129,7 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-test-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                restore-keys: bazelcache-linux-ubuntu-test-${{ github.ref_name }}-
                 
             - name: "Set up Python"
               uses: actions/setup-python@v4

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -22,7 +22,9 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-pi3hat-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                restore-keys: |
+                  bazelcache-linux-pi3hat-${{ github.ref_name }}-
+                  bazelcache-linux-pi3hat-main-
           
             - name: "Install dependencies"
               run: |
@@ -54,7 +56,9 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-build-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-ubuntu-build-${{ github.ref_name }}-
+                restore-keys: |
+                  bazelcache-linux-ubuntu-build-${{ github.ref_name }}-
+                  bazelcache-linux-ubuntu-build-main-
 
             - name: "Install dependencies"
               run: |
@@ -79,7 +83,9 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-coverage-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-ubuntu-coverage-${{ github.ref_name }}-
+                restore-keys: |
+                  bazelcache-linux-ubuntu-coverage-${{ github.ref_name }}-
+                  bazelcache-linux-ubuntu-coverage-main-
                 
             - name: "Install dependencies"
               run: |
@@ -109,7 +115,9 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-lint-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-ubuntu-lint-${{ github.ref_name }}-
+                restore-keys: |
+                  bazelcache-linux-ubuntu-lint-${{ github.ref_name }}-
+                  bazelcache-linux-ubuntu-lint-main-
                 
             - name: "Check code formatting"
               env:
@@ -129,7 +137,9 @@ jobs:
               with:
                 path: "/home/runner/.cache/bazel"
                 key: bazelcache-linux-ubuntu-test-${{ github.ref_name }}-${{ github.sha }}
-                restore-keys: bazelcache-linux-ubuntu-test-${{ github.ref_name }}-
+                restore-keys: |
+                  bazelcache-linux-ubuntu-test-${{ github.ref_name }}-
+                  bazelcache-linux-ubuntu-test-main-
                 
             - name: "Set up Python"
               uses: actions/setup-python@v4


### PR DESCRIPTION
Solves #203

Speed up the bazel CI workflow by using cache for github actions.

Try to speed up also the first build on a branch by using multiple keys, so that the first build on a new branch reuses the cache from the last build on main (this would allow to run simple/fast tests on all commits in branches).
- assumes branches are started from main (should evaluate side effects when starting a branch from another -non main- branch)
- currently CI workflow not started om branches outside main (which jobs to launch ?)

