### PR TITLE
make raspunzel argv0 the same as bazel run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CICD: Release jobs for x86 and ARM64 macOS spines
 - Fix duplicate ``data_`` attribute in pi3hat actuation interface
 - observers: Read configuration matrix in base orientation observer
+- raspunzel: argv0 when executing the target is now the same as `bazel run`.
 
 ### Removed
 

--- a/tools/raspunzel
+++ b/tools/raspunzel
@@ -114,7 +114,7 @@ def log_run(target_name: str, arch: str) -> None:
     YELLOW: str = "\033[33m"
     RESET: str = "\033[0m"
 
-    target_message = f"Found target {YELLOW}{target_name}{RESET} "
+    target_message = f"Found target {YELLOW}{target_name}{RESET}"
     target_message += "for build configuration "
     color = RED
     if "opt" in arch:
@@ -164,11 +164,10 @@ def run(workspace: Workspace, target: str, subargs: List[str]) -> None:
 
     execution_path = (
         f"{workspace.bazel_bin}/{target_dir}/"
-        f"{target_name}.runfiles/{workspace.name}/{target_dir}"
     )
 
     os.chdir(execution_path)
-    os.execv(target_name, [target_name] + subargs)
+    os.execv(target_name, [f"{execution_path}/{target_name}"] + subargs)
 
 
 def get_argument_parser() -> argparse.ArgumentParser:

--- a/tools/raspunzel
+++ b/tools/raspunzel
@@ -114,7 +114,7 @@ def log_run(target_name: str, arch: str) -> None:
     YELLOW: str = "\033[33m"
     RESET: str = "\033[0m"
 
-    target_message = f"Found target {YELLOW}{target_name}{RESET}"
+    target_message = f"Found target {YELLOW}{target_name}{RESET} "
     target_message += "for build configuration "
     color = RED
     if "opt" in arch:


### PR DESCRIPTION
Currently, targets run via `make run_xxx` will not be able to find the run files correctly like `bazel run` does, as we do not pass the full path of the executable in our `argv`.

This PR introduces two changes:

1. We now execute `./bazel-bin/target_dir/target` instead of `bazel-bin/target_dir/target.runfiles/upkie/target_dir/target`, both of which seem to be symlinks to the actual executable in the bazel cache directory.
2. We pass the full path of the `symlink` as the first argument when executing the target.

It should be noted I only verified the changes with my own example, so I am not aware of any side effects this PR may present (if there are any).