### PR TITLE
CICD: Update macOS (x86) runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
     build_darwin_x86:
         name: "Build on macOS (x86)"
-        runs-on: macos-latest
+        runs-on: macos-13
         steps:
             - name: "Checkout sources"
               uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - CICD: Release jobs for x86 and ARM64 macOS spines
+- CICD: Update macOS x86 runner images (thanks to @ubgk)
 - Fix duplicate ``data_`` attribute in pi3hat actuation interface
 - observers: Read configuration matrix in base orientation observer
 - raspunzel: argv0 when executing the target is now the same as `bazel run`.


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Thanks @ubgk for pointing this out :+1: 