### PR TITLE
Switch to upkie::cpp namespace in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CICD: Build jobs for x86 and ARM64 macOS spines
-- Import and adapt C++ code from Vulp
+- Import and adapt C++ code from Vulp (`vulp` namespace is now `upkie:cpp`)
 - Log received actuation replies in spine cycles
 - PID balancer: Conda environment file
 - bazelisk: Add support for ARM64 CPUs

--- a/docs/observations.md
+++ b/docs/observations.md
@@ -6,7 +6,7 @@ Here is an index of observation dictionaries. Keys are a shorthand for nested di
 |-----------------|-------------|
 | `base_orientation.angular_velocity` | Body angular velocity of the base frame in [rad] / [s] |
 | `base_orientation.pitch` | Pitch angle of the base frame relative to the world frame, in radians |
-| `imu` | Inertial measurement unit on the pi3hat. See also \ref upkie::actuation::ImuData |
+| `imu` | Inertial measurement unit on the pi3hat. See also \ref upkie::cpp::actuation::ImuData |
 | `imu.angular_velocity` | Body angular velocity of the IMU frame in [rad] / [s] |
 | `imu.linear_acceleration` | Body linear acceleration of the IMU in [m] / [s]² |
 | `imu.orientation` | Unit quaternion (``qw``, ``qx``, ``qy``, ``qz``) of the orientation from the IMU frame to the attitude reference system (ARS) frame |
@@ -15,8 +15,8 @@ Here is an index of observation dictionaries. Keys are a shorthand for nested di
 | `servos.X.position` | Angle between the stator and the rotor in [rad] |
 | `servos.X.torque` | Joint torque in [N] * [m] |
 | `servos.X.velocity` | Angular velocity of the rotor w.r.t. stator in rotor, in [rad] / [s] |
-| `wheel_odometry.position` | Ground position in [m], see \ref upkie::observers::WheelOdometry |
-| `wheel_odometry.velocity` | Ground velocity in [m] / [s], see \ref upkie::observers::WheelOdometry |
+| `wheel_odometry.position` | Ground position in [m], see \ref upkie::cpp::observers::WheelOdometry |
+| `wheel_odometry.velocity` | Ground velocity in [m] / [s], see \ref upkie::cpp::observers::WheelOdometry |
 
 See also [Sensors](\ref sensors).
 

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -32,16 +32,16 @@
 namespace spines::bullet {
 
 using palimpsest::Dictionary;
-using upkie::actuation::BulletInterface;
-using upkie::observers::BaseOrientation;
-using upkie::observers::FloorContact;
-using upkie::observers::ObserverPipeline;
-using upkie::observers::WheelOdometry;
-using upkie::sensors::CpuTemperature;
-using upkie::spine::Spine;
+using upkie::cpp::actuation::BulletInterface;
+using upkie::cpp::observers::BaseOrientation;
+using upkie::cpp::observers::FloorContact;
+using upkie::cpp::observers::ObserverPipeline;
+using upkie::cpp::observers::WheelOdometry;
+using upkie::cpp::sensors::CpuTemperature;
+using upkie::cpp::spine::Spine;
 
 #ifndef __APPLE__
-using upkie::sensors::Joystick;
+using upkie::cpp::sensors::Joystick;
 #endif
 
 //! Command-line arguments for the Bullet spine.
@@ -207,8 +207,8 @@ int main(const char* argv0, const CommandLineArguments& args) {
   // Observation: Floor contact
   FloorContact::Parameters floor_contact_params;
   floor_contact_params.dt = 1.0 / args.spine_frequency;
-  floor_contact_params.upper_leg_joints = upkie::model::upper_leg_joints();
-  floor_contact_params.wheels = upkie::model::wheel_joints();
+  floor_contact_params.upper_leg_joints = upkie::cpp::model::upper_leg_joints();
+  floor_contact_params.wheels = upkie::cpp::model::wheel_joints();
   auto floor_contact = std::make_shared<FloorContact>(floor_contact_params);
   observation.append_observer(floor_contact);
 
@@ -222,7 +222,7 @@ int main(const char* argv0, const CommandLineArguments& args) {
   // a "b3AlignedObjectArray reserve out-of-memory" error below.
 
   // Simulator
-  const auto servo_layout = upkie::model::servo_layout();
+  const auto servo_layout = upkie::cpp::model::servo_layout();
   const double base_altitude = args.space ? 0.0 : 0.6;  // [m]
   BulletInterface::Parameters bullet_params(Dictionary{});
   bullet_params.argv0 = argv0;
@@ -239,7 +239,7 @@ int main(const char* argv0, const CommandLineArguments& args) {
   Spine::Parameters spine_params;
   spine_params.frequency = args.spine_frequency;
   spine_params.log_path =
-      upkie::utils::get_log_path(args.log_dir, "bullet_spine");
+      upkie::cpp::utils::get_log_path(args.log_dir, "bullet_spine");
   spine_params.shm_name = args.shm_name;
   spdlog::info("Spine data logged to {}", spine_params.log_path);
   Spine spine(spine_params, interface, observation);
@@ -263,7 +263,7 @@ int main(int argc, char** argv) {
     args.print_usage(argv[0]);
     return EXIT_SUCCESS;
   } else if (args.version) {
-    std::cout << "Upkie bullet spine " << upkie::kVersion << "\n";
+    std::cout << "Upkie bullet spine " << upkie::cpp::kVersion << "\n";
     return EXIT_SUCCESS;
   }
   return spines::bullet::main(argv[0], args);

--- a/spines/mock_spine.cpp
+++ b/spines/mock_spine.cpp
@@ -32,16 +32,16 @@
 namespace spines::mock {
 
 using palimpsest::Dictionary;
-using upkie::actuation::MockInterface;
-using upkie::observers::BaseOrientation;
-using upkie::observers::FloorContact;
-using upkie::observers::ObserverPipeline;
-using upkie::observers::WheelOdometry;
-using upkie::sensors::CpuTemperature;
-using upkie::spine::Spine;
+using upkie::cpp::actuation::MockInterface;
+using upkie::cpp::observers::BaseOrientation;
+using upkie::cpp::observers::FloorContact;
+using upkie::cpp::observers::ObserverPipeline;
+using upkie::cpp::observers::WheelOdometry;
+using upkie::cpp::sensors::CpuTemperature;
+using upkie::cpp::spine::Spine;
 
 #ifndef __APPLE__
-using upkie::sensors::Joystick;
+using upkie::cpp::sensors::Joystick;
 #endif
 
 //! Command-line arguments for the mock spine.
@@ -118,7 +118,7 @@ class CommandLineArguments {
 };
 
 int main(const CommandLineArguments& args) {
-  if (!upkie::utils::lock_memory()) {
+  if (!upkie::cpp::utils::lock_memory()) {
     spdlog::error("could not lock process memory to RAM");
     return -4;
   }
@@ -147,8 +147,8 @@ int main(const CommandLineArguments& args) {
   // Observation: Floor contact
   FloorContact::Parameters floor_contact_params;
   floor_contact_params.dt = 1.0 / args.spine_frequency;
-  floor_contact_params.upper_leg_joints = upkie::model::upper_leg_joints();
-  floor_contact_params.wheels = upkie::model::wheel_joints();
+  floor_contact_params.upper_leg_joints = upkie::cpp::model::upper_leg_joints();
+  floor_contact_params.wheels = upkie::cpp::model::wheel_joints();
   auto floor_contact = std::make_shared<FloorContact>(floor_contact_params);
   observation.append_observer(floor_contact);
 
@@ -159,7 +159,7 @@ int main(const CommandLineArguments& args) {
   observation.append_observer(odometry);
 
   // Mock actuators
-  const auto servo_layout = upkie::model::servo_layout();
+  const auto servo_layout = upkie::cpp::model::servo_layout();
   const double dt = 1.0 / args.spine_frequency;
   MockInterface actuation(servo_layout, dt);
 
@@ -168,7 +168,7 @@ int main(const CommandLineArguments& args) {
   spine_params.cpu = args.spine_cpu;
   spine_params.frequency = args.spine_frequency;
   spine_params.log_path =
-      upkie::utils::get_log_path(args.log_dir, "mock_spine");
+      upkie::cpp::utils::get_log_path(args.log_dir, "mock_spine");
   spdlog::info("Spine data logged to {}", spine_params.log_path);
   Spine spine(spine_params, actuation, observation);
   spine.run();
@@ -186,7 +186,7 @@ int main(int argc, char** argv) {
     args.print_usage(argv[0]);
     return EXIT_SUCCESS;
   } else if (args.version) {
-    std::cout << "Upkie mock spine " << upkie::kVersion << "\n";
+    std::cout << "Upkie mock spine " << upkie::cpp::kVersion << "\n";
     return EXIT_SUCCESS;
   }
   return spines::mock::main(args);

--- a/spines/pi3hat_spine.cpp
+++ b/spines/pi3hat_spine.cpp
@@ -33,14 +33,14 @@ namespace spines::pi3hat {
 
 using Pi3Hat = ::mjbots::pi3hat::Pi3Hat;
 using palimpsest::Dictionary;
-using upkie::actuation::Pi3HatInterface;
-using upkie::observers::BaseOrientation;
-using upkie::observers::FloorContact;
-using upkie::observers::ObserverPipeline;
-using upkie::observers::WheelOdometry;
-using upkie::sensors::CpuTemperature;
-using upkie::sensors::Joystick;
-using upkie::spine::Spine;
+using upkie::cpp::actuation::Pi3HatInterface;
+using upkie::cpp::observers::BaseOrientation;
+using upkie::cpp::observers::FloorContact;
+using upkie::cpp::observers::ObserverPipeline;
+using upkie::cpp::observers::WheelOdometry;
+using upkie::cpp::sensors::CpuTemperature;
+using upkie::cpp::sensors::Joystick;
+using upkie::cpp::spine::Spine;
 
 //! Command-line arguments for the Bullet spine.
 class CommandLineArguments {
@@ -153,7 +153,7 @@ int main(const CommandLineArguments& args) {
     spdlog::error("Calibration needed: did you run `upkie_tool rezero`?");
     return -3;
   }
-  if (!upkie::utils::lock_memory()) {
+  if (!upkie::cpp::utils::lock_memory()) {
     spdlog::error("Could not lock process memory to RAM");
     return -4;
   }
@@ -188,8 +188,8 @@ int main(const CommandLineArguments& args) {
   // Observation: Floor contact
   FloorContact::Parameters floor_contact_params;
   floor_contact_params.dt = 1.0 / args.spine_frequency;
-  floor_contact_params.upper_leg_joints = upkie::model::upper_leg_joints();
-  floor_contact_params.wheels = upkie::model::wheel_joints();
+  floor_contact_params.upper_leg_joints = upkie::cpp::model::upper_leg_joints();
+  floor_contact_params.wheels = upkie::cpp::model::wheel_joints();
   auto floor_contact = std::make_shared<FloorContact>(floor_contact_params);
   observation.append_observer(floor_contact);
 
@@ -208,7 +208,7 @@ int main(const CommandLineArguments& args) {
     pi3hat_config.mounting_deg.yaw = 0.;
 
     // pi3hat interface
-    const auto servo_layout = upkie::model::servo_layout();
+    const auto servo_layout = upkie::cpp::model::servo_layout();
     Pi3HatInterface interface(servo_layout, args.can_cpu, pi3hat_config);
 
     // Spine
@@ -216,7 +216,7 @@ int main(const CommandLineArguments& args) {
     spine_params.cpu = args.spine_cpu;
     spine_params.frequency = args.spine_frequency;
     spine_params.log_path =
-        upkie::utils::get_log_path(args.log_dir, "pi3hat_spine");
+        upkie::cpp::utils::get_log_path(args.log_dir, "pi3hat_spine");
     spdlog::info("Spine data logged to {}", spine_params.log_path);
     Spine spine(spine_params, interface, observation);
     spine.run();
@@ -242,7 +242,7 @@ int main(int argc, char** argv) {
     args.print_usage(argv[0]);
     return EXIT_SUCCESS;
   } else if (args.version) {
-    std::cout << "Upkie pi3hat spine " << upkie::kVersion << "\n";
+    std::cout << "Upkie pi3hat spine " << upkie::cpp::kVersion << "\n";
     return EXIT_SUCCESS;
   }
   return spines::pi3hat::main(args);

--- a/upkie/cpp/actuation/BulletContactData.h
+++ b/upkie/cpp/actuation/BulletContactData.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 /*! Contact information for a single link.
  *
@@ -17,4 +17,4 @@ struct BulletContactData {
   int num_contact_points;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/BulletImuData.h
+++ b/upkie/cpp/actuation/BulletImuData.h
@@ -8,7 +8,7 @@
 #include "RobotSimulator/b3RobotSimulatorClientAPI.h"
 #include "upkie/cpp/actuation/ImuData.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 //! IMU data with extra groundtruth observations from Bullet.
 struct BulletImuData : public ImuData {
@@ -16,4 +16,4 @@ struct BulletImuData : public ImuData {
   Eigen::Vector3d linear_velocity_imu_in_world = Eigen::Vector3d::Zero();
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -10,7 +10,7 @@
 #include "tools/cpp/runfiles/runfiles.h"
 #include "upkie/cpp/actuation/bullet/utils.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 using bazel::tools::cpp::runfiles::Runfiles;
 using bullet::bullet_from_eigen;
@@ -452,4 +452,4 @@ Eigen::Vector3d BulletInterface::compute_position_com_in_world() {
   return bullet::compute_position_com_in_world(bullet_, robot_);
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -19,7 +19,7 @@
 #include "upkie/cpp/actuation/moteus/Output.h"
 #include "upkie/cpp/actuation/moteus/ServoReply.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 //! Actuation interface for the Bullet simulator.
 class BulletInterface : public Interface {
@@ -369,4 +369,4 @@ class BulletInterface : public Interface {
   std::map<std::string, BulletContactData> contact_data_;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/BulletJointProperties.h
+++ b/upkie/cpp/actuation/BulletJointProperties.h
@@ -7,7 +7,7 @@
 
 #include "RobotSimulator/b3RobotSimulatorClientAPI.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 //! Properties for robot joints in the Bullet simulation.
 struct BulletJointProperties {
@@ -18,4 +18,4 @@ struct BulletJointProperties {
   double maximum_torque = 0.0;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/ImuData.h
+++ b/upkie/cpp/actuation/ImuData.h
@@ -6,7 +6,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 //! Data filtered from an onboard IMU such as the pi3hat's.
 struct ImuData {
@@ -39,4 +39,4 @@ struct ImuData {
   Eigen::Vector3d linear_acceleration_imu_in_imu = Eigen::Vector3d::Zero();
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/Interface.cpp
+++ b/upkie/cpp/actuation/Interface.cpp
@@ -22,7 +22,7 @@
 #include "upkie/cpp/actuation/moteus/Mode.h"
 #include "upkie/cpp/actuation/moteus/ServoCommand.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 void Interface::initialize_action(Dictionary& action) {
   for (const auto& id_joint : servo_layout_.servo_joint_map()) {
@@ -96,4 +96,4 @@ void Interface::write_position_commands(const Dictionary& action) {
   }
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/Interface.h
+++ b/upkie/cpp/actuation/Interface.h
@@ -16,7 +16,7 @@
 #include "upkie/cpp/actuation/resolution.h"
 
 //! Send actions to actuators or simulators.
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 using palimpsest::Dictionary;
 
@@ -155,4 +155,4 @@ class Interface {
   std::vector<moteus::ServoReply> replies_;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/MockInterface.cpp
+++ b/upkie/cpp/actuation/MockInterface.cpp
@@ -6,7 +6,7 @@
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 MockInterface::MockInterface(const ServoLayout& layout, const double dt)
     : Interface(layout), dt_(dt) {
@@ -67,4 +67,4 @@ void MockInterface::cycle(std::function<void(const moteus::Output&)> callback) {
   callback(output);
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/MockInterface.h
+++ b/upkie/cpp/actuation/MockInterface.h
@@ -15,7 +15,7 @@
 #include "upkie/cpp/actuation/Interface.h"
 #include "upkie/cpp/actuation/moteus/protocol.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 //! Interface whose internal state perfectly tracks commands.
 class MockInterface : public Interface {
@@ -69,4 +69,4 @@ class MockInterface : public Interface {
   ImuData imu_data_;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/Pi3HatInterface.cpp
+++ b/upkie/cpp/actuation/Pi3HatInterface.cpp
@@ -10,7 +10,7 @@
 
 #include "upkie/cpp/actuation/Pi3HatInterface.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 Pi3HatInterface::Pi3HatInterface(
     const ServoLayout& layout, const int can_cpu,
@@ -69,8 +69,8 @@ void Pi3HatInterface::cycle(
 }
 
 void Pi3HatInterface::run_can_thread() {
-  upkie::utils::configure_cpu(can_cpu_);
-  upkie::utils::configure_scheduler(10);
+  upkie::cpp::utils::configure_cpu(can_cpu_);
+  upkie::cpp::utils::configure_scheduler(10);
   pi3hat_.reset(new ::mjbots::pi3hat::Pi3Hat({pi3hat_config_}));
   pthread_setname_np(pthread_self(), "can_thread");
   while (!done_) {
@@ -162,4 +162,4 @@ moteus::Output Pi3HatInterface::cycle_can_thread() {
   return result;
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/Pi3HatInterface.h
+++ b/upkie/cpp/actuation/Pi3HatInterface.h
@@ -31,7 +31,7 @@
 #include "upkie/cpp/actuation/moteus/protocol.h"
 #include "upkie/cpp/utils/realtime.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 /*! Interface to moteus controllers.
  *
@@ -178,4 +178,4 @@ class Pi3HatInterface : public Interface {
   ::mjbots::pi3hat::Attitude attitude_;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/ServoLayout.h
+++ b/upkie/cpp/actuation/ServoLayout.h
@@ -6,7 +6,7 @@
 #include <map>
 #include <string>
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 //! Map between servos, their busses and the joints they actuate.
 class ServoLayout {
@@ -66,4 +66,4 @@ class ServoLayout {
   std::map<int, std::string> servo_joint_map_;
 };
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/bullet/utils.h
+++ b/upkie/cpp/actuation/bullet/utils.h
@@ -10,7 +10,7 @@
 #include "RobotSimulator/b3RobotSimulatorClientAPI.h"
 #include "upkie/cpp/actuation/BulletImuData.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace bullet {
 
@@ -232,4 +232,4 @@ Eigen::Vector3d compute_position_com_in_world(b3RobotSimulatorClientAPI& bullet,
 
 }  // namespace bullet
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/default_action.h
+++ b/upkie/cpp/actuation/default_action.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace default_action {
 
@@ -15,4 +15,4 @@ constexpr double kMaximumTorque = 1.0;      // N.m
 
 }  // namespace default_action
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/Data.h
+++ b/upkie/cpp/actuation/moteus/Data.h
@@ -14,7 +14,7 @@
 #include "upkie/cpp/actuation/moteus/ServoReply.h"
 #include "upkie/cpp/actuation/moteus/Span.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -33,4 +33,4 @@ struct Data {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/Mode.h
+++ b/upkie/cpp/actuation/moteus/Mode.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -34,4 +34,4 @@ enum class Mode {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/Output.h
+++ b/upkie/cpp/actuation/moteus/Output.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -22,4 +22,4 @@ struct Output {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/PositionCommand.h
+++ b/upkie/cpp/actuation/moteus/PositionCommand.h
@@ -12,7 +12,7 @@
 
 #include <limits>
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -20,7 +20,7 @@ namespace moteus {
  *
  * \note Default values here are also the initial joint values for the mock
  * interface. See the documentation at \ref
- * upkie::MockInterface::ServoState::step.
+ * upkie::cpp::MockInterface::ServoState::step.
  */
 struct PositionCommand {
   double position = 0.0;
@@ -35,4 +35,4 @@ struct PositionCommand {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/PositionResolution.h
+++ b/upkie/cpp/actuation/moteus/PositionResolution.h
@@ -12,7 +12,7 @@
 
 #include "upkie/cpp/actuation/moteus/Resolution.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -29,4 +29,4 @@ struct PositionResolution {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/QueryCommand.h
+++ b/upkie/cpp/actuation/moteus/QueryCommand.h
@@ -12,7 +12,7 @@
 
 #include "upkie/cpp/actuation/moteus/Resolution.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -41,4 +41,4 @@ struct QueryCommand {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/QueryResult.h
+++ b/upkie/cpp/actuation/moteus/QueryResult.h
@@ -14,7 +14,7 @@
 
 #include "upkie/cpp/actuation/moteus/Mode.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -52,4 +52,4 @@ struct QueryResult {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/Resolution.h
+++ b/upkie/cpp/actuation/moteus/Resolution.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -24,4 +24,4 @@ enum class Resolution {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/ServoCommand.h
+++ b/upkie/cpp/actuation/moteus/ServoCommand.h
@@ -15,7 +15,7 @@
 #include "upkie/cpp/actuation/moteus/PositionResolution.h"
 #include "upkie/cpp/actuation/moteus/QueryCommand.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -39,4 +39,4 @@ struct ServoCommand {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/ServoReply.h
+++ b/upkie/cpp/actuation/moteus/ServoReply.h
@@ -12,7 +12,7 @@
 
 #include "upkie/cpp/actuation/moteus/QueryResult.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -27,4 +27,4 @@ struct ServoReply {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/Span.h
+++ b/upkie/cpp/actuation/moteus/Span.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -68,4 +68,4 @@ class Span {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/moteus/protocol.h
+++ b/upkie/cpp/actuation/moteus/protocol.h
@@ -34,7 +34,7 @@
  * CAN-FD packets for the moteus brushless servo.
  */
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace moteus {
 
@@ -655,4 +655,4 @@ inline QueryResult ParseQueryResult(const uint8_t* data, size_t size) {
 
 }  // namespace moteus
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/resolution.h
+++ b/upkie/cpp/actuation/resolution.h
@@ -6,7 +6,7 @@
 #include "upkie/cpp/actuation/moteus/PositionResolution.h"
 #include "upkie/cpp/actuation/moteus/QueryCommand.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 /*! Query resolution settings for all servo commands.
  *
@@ -52,4 +52,4 @@ inline moteus::PositionResolution get_position_resolution() {
   return resolution;
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -12,7 +12,7 @@
 #include "tools/cpp/runfiles/runfiles.h"
 #include "upkie/cpp/actuation/BulletInterface.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 using bazel::tools::cpp::runfiles::Runfiles;
 
@@ -411,4 +411,4 @@ TEST_F(BulletInterfaceTest, ApplyExternalForces) {
   }
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/InterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/InterfaceTest.cpp
@@ -10,7 +10,7 @@
 #include "upkie/cpp/actuation/Interface.h"
 #include "upkie/cpp/actuation/tests/coffee_machine_layout.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 class SmallInterface : public Interface {
  public:
@@ -148,4 +148,4 @@ TEST_F(InterfaceTest, ForwardVelocityCommands) {
   }
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/MockInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/MockInterfaceTest.cpp
@@ -8,7 +8,7 @@
 #include "upkie/cpp/actuation/moteus/protocol.h"
 #include "upkie/cpp/actuation/tests/coffee_machine_layout.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 TEST(MockInterfaceTest, CycleCallsCallback) {
   const auto layout = get_coffee_machine_layout();
@@ -22,4 +22,4 @@ TEST(MockInterfaceTest, CycleCallsCallback) {
   ASSERT_TRUE(callback_called);
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/Pi3HatInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/Pi3HatInterfaceTest.cpp
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/actuation/Pi3HatInterface.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 TEST(Pi3HatInterface, Create) {
   ServoLayout layout;
@@ -31,4 +31,4 @@ TEST(Pi3HatInterface, Create) {
   Pi3HatInterface interface(layout, kCanCpu, pi3hat_config);
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/bullet_utils_test.cpp
+++ b/upkie/cpp/actuation/tests/bullet_utils_test.cpp
@@ -13,7 +13,7 @@
 
 using bazel::tools::cpp::runfiles::Runfiles;
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 namespace bullet {
 
@@ -130,4 +130,4 @@ TEST_F(BulletTest, ComputeCenterOfMass) {
 
 }  // namespace bullet
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/coffee_machine_layout.h
+++ b/upkie/cpp/actuation/tests/coffee_machine_layout.h
@@ -5,7 +5,7 @@
 
 #include "upkie/cpp/actuation/ServoLayout.h"
 
-namespace upkie::actuation {
+namespace upkie::cpp::actuation {
 
 /*! Get a sample servo layout.
  *
@@ -20,4 +20,4 @@ inline const ServoLayout get_coffee_machine_layout() noexcept {
   return layout;
 }
 
-}  // namespace upkie::actuation
+}  // namespace upkie::cpp::actuation

--- a/upkie/cpp/exceptions/FilterError.h
+++ b/upkie/cpp/exceptions/FilterError.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-namespace upkie::exceptions {
+namespace upkie::cpp::exceptions {
 
 //! Exception for filter errors
 class FilterError : public std::runtime_error {
@@ -24,4 +24,4 @@ class FilterError : public std::runtime_error {
   const char* what() const throw() { return std::runtime_error::what(); }
 };
 
-}  // namespace upkie::exceptions
+}  // namespace upkie::cpp::exceptions

--- a/upkie/cpp/exceptions/ObserverError.h
+++ b/upkie/cpp/exceptions/ObserverError.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-namespace upkie::exceptions {
+namespace upkie::cpp::exceptions {
 
 //! Exception thrown when an observer fails.
 class ObserverError : public std::runtime_error {
@@ -45,4 +45,4 @@ class ObserverError : public std::runtime_error {
   std::string message_;
 };
 
-}  // namespace upkie::exceptions
+}  // namespace upkie::cpp::exceptions

--- a/upkie/cpp/exceptions/TypeError.h
+++ b/upkie/cpp/exceptions/TypeError.h
@@ -7,7 +7,7 @@
 
 #include "upkie/cpp/exceptions/UpkieError.h"
 
-namespace upkie::exceptions {
+namespace upkie::cpp::exceptions {
 
 //! Exception raised when a deserialized object does not have the right type.
 class TypeError : public UpkieError {
@@ -33,4 +33,4 @@ class TypeError : public UpkieError {
   ~TypeError() throw() {}
 };
 
-}  // namespace upkie::exceptions
+}  // namespace upkie::cpp::exceptions

--- a/upkie/cpp/exceptions/UpkieError.h
+++ b/upkie/cpp/exceptions/UpkieError.h
@@ -6,7 +6,7 @@
 #include <string>
 
 //! Exceptions raised by this project.
-namespace upkie::exceptions {
+namespace upkie::cpp::exceptions {
 
 //! Error with file and line references to the calling code.
 class UpkieError : public std::runtime_error {
@@ -44,4 +44,4 @@ class UpkieError : public std::runtime_error {
   std::string message_;
 };
 
-}  // namespace upkie::exceptions
+}  // namespace upkie::cpp::exceptions

--- a/upkie/cpp/exceptions/tests/observer_error_test.cpp
+++ b/upkie/cpp/exceptions/tests/observer_error_test.cpp
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/exceptions/ObserverError.h"
 
-namespace upkie::exceptions {
+namespace upkie::cpp::exceptions {
 
 TEST(ObserverError, NineteenSixtyWho) {
   const std::string prefix = "nineteen_sixty";
@@ -20,4 +20,4 @@ TEST(ObserverError, NineteenSixtyWho) {
   ASSERT_NE(msg.find(key), std::string::npos);
 }
 
-}  // namespace upkie::exceptions
+}  // namespace upkie::cpp::exceptions

--- a/upkie/cpp/model/joints.h
+++ b/upkie/cpp/model/joints.h
@@ -8,7 +8,7 @@
 
 #include "upkie/cpp/actuation/ServoLayout.h"
 
-namespace upkie::model {
+namespace upkie::cpp::model {
 
 /*! Get list of upper leg joints, i.e. hips and knees.
  *
@@ -26,4 +26,4 @@ inline const std::vector<std::string> wheel_joints() noexcept {
   return {"left_wheel", "right_wheel"};
 }
 
-}  // namespace upkie::model
+}  // namespace upkie::cpp::model

--- a/upkie/cpp/model/servo_layout.h
+++ b/upkie/cpp/model/servo_layout.h
@@ -8,9 +8,9 @@
 
 #include "upkie/cpp/actuation/ServoLayout.h"
 
-namespace upkie::model {
+namespace upkie::cpp::model {
 
-using upkie::actuation::ServoLayout;
+using upkie::cpp::actuation::ServoLayout;
 
 constexpr int kLeftBusID = 1;   // JC1
 constexpr int kRightBusID = 3;  // JC3
@@ -30,4 +30,4 @@ inline const ServoLayout servo_layout() noexcept {
   return layout;
 }
 
-}  // namespace upkie::model
+}  // namespace upkie::cpp::model

--- a/upkie/cpp/observers/BaseOrientation.cpp
+++ b/upkie/cpp/observers/BaseOrientation.cpp
@@ -3,7 +3,7 @@
 
 #include "upkie/cpp/observers/BaseOrientation.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 BaseOrientation::BaseOrientation(const Parameters& params) : params_(params) {}
 
@@ -36,4 +36,4 @@ void BaseOrientation::write(Dictionary& observation) {
   output("angular_velocity") = angular_velocity_base_in_base_;
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/BaseOrientation.h
+++ b/upkie/cpp/observers/BaseOrientation.h
@@ -11,7 +11,7 @@
 
 #include "upkie/cpp/observers/Observer.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -233,4 +233,4 @@ class BaseOrientation : public Observer {
   Eigen::Vector3d angular_velocity_base_in_base_;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/FloorContact.cpp
+++ b/upkie/cpp/observers/FloorContact.cpp
@@ -7,10 +7,10 @@
 
 #include "upkie/cpp/utils/low_pass_filter.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::exceptions::KeyError;
-using upkie::utils::low_pass_filter;
+using upkie::cpp::utils::low_pass_filter;
 
 FloorContact::FloorContact(const Parameters& params)
     : params_(params), upper_leg_torque_(0.0), contact_(false) {
@@ -101,4 +101,4 @@ void FloorContact::write(Dictionary& observation) {
   }
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/FloorContact.h
+++ b/upkie/cpp/observers/FloorContact.h
@@ -18,7 +18,7 @@
  * \image html observers.png
  * \image latex observers.eps
  */
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -141,4 +141,4 @@ class FloorContact : public Observer {
   bool contact_;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/HistoryObserver.h
+++ b/upkie/cpp/observers/HistoryObserver.h
@@ -13,7 +13,7 @@
 #include "upkie/cpp/exceptions/TypeError.h"
 #include "upkie/cpp/observers/Observer.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -116,4 +116,4 @@ class HistoryObserver : public Observer {
   std::vector<T> values_;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/Observer.h
+++ b/upkie/cpp/observers/Observer.h
@@ -7,7 +7,7 @@
 
 #include <string>
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -47,4 +47,4 @@ class Observer {
   virtual void write(Dictionary& observation) {}
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/ObserverPipeline.cpp
+++ b/upkie/cpp/observers/ObserverPipeline.cpp
@@ -7,7 +7,7 @@
 
 #include "upkie/cpp/exceptions/ObserverError.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::exceptions::KeyError;
 
@@ -35,4 +35,4 @@ void ObserverPipeline::run(Dictionary& observation) {
   }
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/ObserverPipeline.h
+++ b/upkie/cpp/observers/ObserverPipeline.h
@@ -10,7 +10,7 @@
 #include "upkie/cpp/sensors/Sensor.h"
 
 //! State observation.
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 /*! Observer pipeline.
  *
@@ -21,7 +21,7 @@ namespace upkie::observers {
  */
 class ObserverPipeline {
   using Dictionary = palimpsest::Dictionary;
-  using Sensor = upkie::sensors::Sensor;
+  using Sensor = upkie::cpp::sensors::Sensor;
 
  public:
   /*! Reset observers.
@@ -76,4 +76,4 @@ class ObserverPipeline {
   std::vector<std::shared_ptr<Observer>> observers_;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/WheelContact.cpp
+++ b/upkie/cpp/observers/WheelContact.cpp
@@ -5,9 +5,9 @@
 
 #include "upkie/cpp/utils/low_pass_filter.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
-using upkie::utils::low_pass_filter;
+using upkie::cpp::utils::low_pass_filter;
 
 WheelContact::WheelContact(const Parameters& params)
     : params_(params),
@@ -48,4 +48,4 @@ void WheelContact::observe(const double torque, const double velocity,
   }
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/WheelContact.h
+++ b/upkie/cpp/observers/WheelContact.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <limits>
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -142,4 +142,4 @@ class WheelContact {
   double velocity_;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/WheelOdometry.cpp
+++ b/upkie/cpp/observers/WheelOdometry.cpp
@@ -3,7 +3,7 @@
 
 #include "upkie/cpp/observers/WheelOdometry.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 WheelOdometry::WheelOdometry(const Parameters& params)
     : params_(params), position_(0.0), velocity_(0.0) {}
@@ -60,4 +60,4 @@ void WheelOdometry::write(Dictionary& observation) {
   output("velocity") = velocity_;
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/WheelOdometry.h
+++ b/upkie/cpp/observers/WheelOdometry.h
@@ -12,7 +12,7 @@
 
 #include "upkie/cpp/observers/Observer.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -153,4 +153,4 @@ class WheelOdometry : public Observer {
   double velocity_;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/observe_servos.cpp
+++ b/upkie/cpp/observers/observe_servos.cpp
@@ -7,9 +7,9 @@
 #include <string>
 #include <vector>
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
-using upkie::actuation::moteus::ServoReply;
+using upkie::cpp::actuation::moteus::ServoReply;
 
 void observe_servos(palimpsest::Dictionary& observation,
                     const std::map<int, std::string>& servo_joint_map,
@@ -44,4 +44,4 @@ void observe_servos(palimpsest::Dictionary& observation,
   }
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/observe_servos.h
+++ b/upkie/cpp/observers/observe_servos.h
@@ -11,9 +11,9 @@
 
 #include "upkie/cpp/actuation/moteus/protocol.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
-using upkie::actuation::moteus::ServoReply;
+using upkie::cpp::actuation::moteus::ServoReply;
 
 /*! Observe servo measurements.
  *
@@ -25,4 +25,4 @@ void observe_servos(palimpsest::Dictionary& observation,
                     const std::map<int, std::string>& servo_joint_map,
                     const std::vector<ServoReply>& servo_replies);
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/observe_time.h
+++ b/upkie/cpp/observers/observe_time.h
@@ -5,7 +5,7 @@
 
 #include <palimpsest/Dictionary.h>
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -22,4 +22,4 @@ inline void observe_time(Dictionary& observation) {
   observation("time") = static_cast<double>(nb_us) / 1e6;
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/BaseOrientationTest.cpp
+++ b/upkie/cpp/observers/tests/BaseOrientationTest.cpp
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/observers/BaseOrientation.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 using palimpsest::exceptions::KeyError;
@@ -108,4 +108,4 @@ TEST_F(BaseOrientationTest, NeutralValues) {
   ASSERT_DOUBLE_EQ(angular_velocity_base_in_base.z(), 0.0);
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/FloorContactTest.cpp
+++ b/upkie/cpp/observers/tests/FloorContactTest.cpp
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/observers/FloorContact.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 using palimpsest::exceptions::KeyError;
@@ -145,4 +145,4 @@ TEST_F(FloorContactTest, BigLegTorqueMeansContact) {
   ASSERT_TRUE(observation("floor_contact").get<bool>("contact"));
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/HistoryObserverTest.cpp
+++ b/upkie/cpp/observers/tests/HistoryObserverTest.cpp
@@ -12,7 +12,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/observers/HistoryObserver.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 
@@ -101,4 +101,4 @@ TEST(HistoryObserver, Vector3dReadThenWrite) {
   ASSERT_DOUBLE_EQ(values[2].z(), 3.2);
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/ObserverTest.cpp
+++ b/upkie/cpp/observers/tests/ObserverTest.cpp
@@ -7,7 +7,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/observers/Observer.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 TEST(Observer, BaseClassObservesNothing) {
   Observer observer;
@@ -18,4 +18,4 @@ TEST(Observer, BaseClassObservesNothing) {
   ASSERT_TRUE(observation.is_empty());
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/SchwiftyObserver.h
+++ b/upkie/cpp/observers/tests/SchwiftyObserver.h
@@ -8,7 +8,7 @@
 
 #include "upkie/cpp/observers/Observer.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::exceptions::KeyError;
 
@@ -31,4 +31,4 @@ class SchwiftyObserver : public Observer {
   bool throw_key_error = false;
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/ThrowingObserver.h
+++ b/upkie/cpp/observers/tests/ThrowingObserver.h
@@ -7,7 +7,7 @@
 
 #include "upkie/cpp/observers/Observer.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 //! Exception-throwing observer
 class ThrowingObserver : public Observer {
@@ -17,4 +17,4 @@ class ThrowingObserver : public Observer {
   }
 };
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/WheelOdometryObserverTest.cpp
+++ b/upkie/cpp/observers/tests/WheelOdometryObserverTest.cpp
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/observers/WheelOdometry.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 using palimpsest::Dictionary;
 using palimpsest::exceptions::KeyError;
@@ -87,4 +87,4 @@ TEST_F(WheelOdometryTest, ZeroVelocityWhenNoContact) {
   ASSERT_DOUBLE_EQ(observation("wheel_odometry")("velocity"), 0.0);
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/observe_servos_test.cpp
+++ b/upkie/cpp/observers/tests/observe_servos_test.cpp
@@ -12,7 +12,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/actuation/moteus/ServoReply.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 TEST(Servo, ReadTorques) {
   palimpsest::Dictionary observation;
@@ -33,4 +33,4 @@ TEST(Servo, ReadTorques) {
   ASSERT_DOUBLE_EQ(observation("servo")("bar")("torque"), -10.);
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/observers/tests/observe_time_test.cpp
+++ b/upkie/cpp/observers/tests/observe_time_test.cpp
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-namespace upkie::observers {
+namespace upkie::cpp::observers {
 
 TEST(Time, ObserveTime) {
   Dictionary observation;
@@ -13,4 +13,4 @@ TEST(Time, ObserveTime) {
   ASSERT_GT(observation.get<double>("time"), 1634311511.42);
 }
 
-}  // namespace upkie::observers
+}  // namespace upkie::cpp::observers

--- a/upkie/cpp/sensors/CpuTemperature.cpp
+++ b/upkie/cpp/sensors/CpuTemperature.cpp
@@ -3,7 +3,7 @@
 
 #include "upkie/cpp/sensors/CpuTemperature.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 CpuTemperature::CpuTemperature(const char* temp_path) : has_warned_(false) {
   fd_ = ::open(temp_path, O_RDONLY | O_NONBLOCK);
@@ -53,4 +53,4 @@ void CpuTemperature::check_temperature_warning(
   }
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/CpuTemperature.h
+++ b/upkie/cpp/sensors/CpuTemperature.h
@@ -7,7 +7,7 @@
 
 #include "upkie/cpp/sensors/Sensor.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 //! Characters required to read the temperature in [mC] from the kernel.
 constexpr unsigned kCpuTemperatureBufferSize = 12;
@@ -64,4 +64,4 @@ class CpuTemperature : public Sensor {
   bool has_warned_;
 };
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/Joystick.cpp
+++ b/upkie/cpp/sensors/Joystick.cpp
@@ -3,7 +3,7 @@
 
 #include "upkie/cpp/sensors/Joystick.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 Joystick::Joystick(const std::string& device_path) {
   fd_ = ::open(device_path.c_str(), O_RDONLY | O_NONBLOCK);
@@ -127,4 +127,4 @@ void Joystick::write(Dictionary& observation) {
   output("triangle_button") = triangle_button_;
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/Joystick.h
+++ b/upkie/cpp/sensors/Joystick.h
@@ -12,7 +12,7 @@
 
 #include "upkie/cpp/sensors/Sensor.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 //! Deadband between 0.0 and 1.0.
 constexpr double kJoystickDeadband = 0.1;
@@ -89,4 +89,4 @@ class Joystick : public Sensor {
   bool triangle_button_ = false;
 };
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/Keyboard.cpp
+++ b/upkie/cpp/sensors/Keyboard.cpp
@@ -3,7 +3,7 @@
 
 #include "upkie/cpp/sensors/Keyboard.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 Keyboard::Keyboard() {
   termios term;
   tcgetattr(STDIN_FILENO, &term);
@@ -112,4 +112,4 @@ void Keyboard::write(Dictionary& observation) {
   output("unknown") = key_code_ == Key::UNKNOWN;
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/Keyboard.h
+++ b/upkie/cpp/sensors/Keyboard.h
@@ -43,7 +43,7 @@ inline bool is_printable_ascii(unsigned char c) {
   return 0x20 <= c && c <= 0x7F;
 }
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 enum class Key {
   UP,
   DOWN,
@@ -111,4 +111,4 @@ class Keyboard : public Sensor {
   system_clock::time_point last_key_poll_time_;
 };
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/Sensor.h
+++ b/upkie/cpp/sensors/Sensor.h
@@ -7,7 +7,7 @@
 
 #include <string>
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 using palimpsest::Dictionary;
 
@@ -41,4 +41,4 @@ class Sensor {
   virtual void write(Dictionary& observation) {}
 };
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/tests/CpuTemperatureTest.cpp
+++ b/upkie/cpp/sensors/tests/CpuTemperatureTest.cpp
@@ -4,7 +4,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/sensors/CpuTemperature.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 TEST(CpuTemperature, NoWriteIfDisabled) {
   CpuTemperature cpu_temperature("/bogus/temp");
@@ -27,4 +27,4 @@ TEST(CpuTemperature, WriteOnce) {
   }
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/tests/JoystickTest.cpp
+++ b/upkie/cpp/sensors/tests/JoystickTest.cpp
@@ -8,7 +8,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/sensors/Joystick.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 TEST(Joystick, WriteOnce) {
   Joystick joystick;
@@ -152,4 +152,4 @@ TEST(Joystick, PartialInput) {
   ASSERT_TRUE(output.get<bool>("cross_button"));
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/tests/KeyboardTest.cpp
+++ b/upkie/cpp/sensors/tests/KeyboardTest.cpp
@@ -6,7 +6,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/sensors/Keyboard.h"
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 TEST(Keyboard, WriteOnce) {
   Keyboard keyboard;
@@ -90,4 +90,4 @@ TEST(Keyboard, ReadEmptySTDIN) {
   ASSERT_FALSE(output.get<bool>("x"));
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/sensors/tests/sensor_test.cpp
+++ b/upkie/cpp/sensors/tests/sensor_test.cpp
@@ -14,7 +14,7 @@
 
 using palimpsest::Dictionary;
 
-namespace upkie::sensors {
+namespace upkie::cpp::sensors {
 
 TEST(Sensor, UnknownPrefix) {
   Sensor sensor;
@@ -28,4 +28,4 @@ TEST(Sensor, WritesNothing) {
   ASSERT_TRUE(observation.is_empty());
 }
 
-}  // namespace upkie::sensors
+}  // namespace upkie::cpp::sensors

--- a/upkie/cpp/spine/AgentInterface.cpp
+++ b/upkie/cpp/spine/AgentInterface.cpp
@@ -6,7 +6,7 @@
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 /*! Allocate file with some error handling.
  *
@@ -97,4 +97,4 @@ void AgentInterface::write(char* data, size_t size) {
   std::memcpy(mmap_data_, data, size);
 }
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/AgentInterface.h
+++ b/upkie/cpp/spine/AgentInterface.h
@@ -22,7 +22,7 @@
  * the cost of more complexity. We choose to go for the simpler (riskier)
  * version where both agent and spine directly manipulate the agenda.
  */
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 /*! Memory map to shared memory.
  *
@@ -85,4 +85,4 @@ class AgentInterface {
   char* mmap_data_;
 };
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/Request.h
+++ b/upkie/cpp/spine/Request.h
@@ -6,7 +6,7 @@
 #include <cstdint>
 
 //! Main control loop between agents and actuators.
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 //! Request flag used for shared-memory inter-process communication.
 enum class Request : uint32_t {
@@ -29,4 +29,4 @@ enum class Request : uint32_t {
   kError = 5
 };
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/Spine.cpp
+++ b/upkie/cpp/spine/Spine.cpp
@@ -20,10 +20,10 @@
 #include "upkie/cpp/utils/handle_interrupts.h"
 #include "upkie/cpp/utils/realtime.h"
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 using palimpsest::Dictionary;
-using upkie::actuation::moteus::Output;
+using upkie::cpp::actuation::moteus::Output;
 
 Spine::Spine(const Parameters& params, actuation::Interface& actuation,
              ObserverPipeline& observers)
@@ -238,4 +238,4 @@ void Spine::cycle_actuation() {
   actuation_output_ = promise->get_future();
 }
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/Spine.h
+++ b/upkie/cpp/spine/Spine.h
@@ -19,7 +19,7 @@
 #include "upkie/cpp/utils/SynchronousClock.h"
 
 //! Main control loop between agents and actuators.
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 //! Number of bits in one mebibyte.
 constexpr size_t kMebibytes = 1 << 20;
@@ -41,9 +41,9 @@ constexpr size_t kMebibytes = 1 << 20;
  * See StateMachine for more details.
  */
 class Spine {
-  using ObserverPipeline = upkie::observers::ObserverPipeline;
-  using Output = upkie::actuation::moteus::Output;
-  using ServoReply = upkie::actuation::moteus::ServoReply;
+  using ObserverPipeline = upkie::cpp::observers::ObserverPipeline;
+  using Output = upkie::cpp::actuation::moteus::Output;
+  using ServoReply = upkie::cpp::actuation::moteus::ServoReply;
 
  public:
   //! Spine parameters.
@@ -184,4 +184,4 @@ class Spine {
   size_t rx_count_;
 };
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/StateMachine.cpp
+++ b/upkie/cpp/spine/StateMachine.cpp
@@ -7,7 +7,7 @@
 
 #include "upkie/cpp/utils/handle_interrupts.h"
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 StateMachine::StateMachine(AgentInterface& interface) noexcept
     : interface_(interface), state_(State::kSendStops), stop_cycles_(0u) {
@@ -162,4 +162,4 @@ void StateMachine::enter_state(const State& next_state) noexcept {
   state_ = next_state;
 }
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/StateMachine.h
+++ b/upkie/cpp/spine/StateMachine.h
@@ -5,7 +5,7 @@
 
 #include "upkie/cpp/spine/AgentInterface.h"
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 //! When sending stop cycles, send at least that many.
 constexpr unsigned kNbStopCycles = 5;
@@ -149,4 +149,4 @@ class StateMachine {
   unsigned stop_cycles_;
 };
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/tests/AgentInterfaceTest.cpp
+++ b/upkie/cpp/spine/tests/AgentInterfaceTest.cpp
@@ -15,7 +15,7 @@
 #include "upkie/cpp/spine/AgentInterface.h"
 #include "upkie/cpp/utils/random_string.h"
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 class AgentInterfaceTest : public ::testing::Test {
  protected:
@@ -44,4 +44,4 @@ TEST_F(AgentInterfaceTest, ReadWriteData) {
   ASSERT_EQ(agent_interface_->size(), size);
 }
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/tests/SpineTest.cpp
+++ b/upkie/cpp/spine/tests/SpineTest.cpp
@@ -22,15 +22,15 @@
 
 using palimpsest::Dictionary;
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 namespace testing {
 
 //! Testing version of the spine class
-class Spine : public upkie::spine::Spine {
+class Spine : public upkie::cpp::spine::Spine {
  public:
   //! Parent constructor.
-  using upkie::spine::Spine::Spine;
+  using upkie::cpp::spine::Spine::Spine;
 
   //! Get agent interface.
   const AgentInterface& agent_interface() { return agent_interface_; }
@@ -302,4 +302,4 @@ TEST_F(SpineTest, EnteringStopClearsRequest) {
   ASSERT_EQ(read_mmap_request(), Request::kNone);
 }
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/tests/StateMachineTest.cpp
+++ b/upkie/cpp/spine/tests/StateMachineTest.cpp
@@ -9,7 +9,7 @@
 #include "upkie/cpp/spine/StateMachine.h"
 #include "upkie/cpp/utils/random_string.h"
 
-namespace upkie::spine {
+namespace upkie::cpp::spine {
 
 class StateMachineTest : public ::testing::Test {
  protected:
@@ -96,4 +96,4 @@ TEST_F(StateMachineTest, ObserveWhenSendingStopsFails) {
   ASSERT_EQ(request(), Request::kError);
 }
 
-}  // namespace upkie::spine
+}  // namespace upkie::cpp::spine

--- a/upkie/cpp/utils/SynchronousClock.cpp
+++ b/upkie/cpp/utils/SynchronousClock.cpp
@@ -15,7 +15,7 @@
 
 #include "upkie/cpp/utils/math.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 SynchronousClock::SynchronousClock(double frequency)
     : period_us_(microseconds(static_cast<int64_t>(1e6 / frequency))),
@@ -59,4 +59,4 @@ void SynchronousClock::wait_for_next_tick() {
   measure_period(call_time);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/SynchronousClock.h
+++ b/upkie/cpp/utils/SynchronousClock.h
@@ -7,7 +7,7 @@
 
 #include <chrono>
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 /*! Synchronous (blocking) clock.
  *
@@ -78,4 +78,4 @@ class SynchronousClock {
   double slack_;
 };
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/datetime_now_string.h
+++ b/upkie/cpp/utils/datetime_now_string.h
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <string>
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 /*! Generate a date-time string.
  *
@@ -24,4 +24,4 @@ inline std::string datetime_now_string() {
   return output.str();
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/get_log_path.h
+++ b/upkie/cpp/utils/get_log_path.h
@@ -14,7 +14,7 @@
 
 #include "upkie/cpp/utils/datetime_now_string.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 /*! Get path to a fresh log file.
  *
@@ -36,4 +36,4 @@ inline const std::string get_log_path(const std::string& log_dir,
   return prefix + hostname + "_" + spine_name + ".mpack";
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/handle_interrupts.cpp
+++ b/upkie/cpp/utils/handle_interrupts.cpp
@@ -3,7 +3,7 @@
 
 #include "upkie/cpp/utils/handle_interrupts.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 namespace internal {
 
@@ -26,4 +26,4 @@ const bool& handle_interrupts() {
   return internal::interrupt_flag;
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/handle_interrupts.h
+++ b/upkie/cpp/utils/handle_interrupts.h
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 namespace internal {
 
@@ -26,4 +26,4 @@ void handle_interrupt(int _);
  */
 const bool& handle_interrupts();
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/low_pass_filter.h
+++ b/upkie/cpp/utils/low_pass_filter.h
@@ -8,7 +8,7 @@
 
 #include "upkie/cpp/exceptions/FilterError.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 /*! Low-pass filter as an inline function.
  *
@@ -36,4 +36,4 @@ inline double low_pass_filter(double prev_output, double cutoff_period,
   return prev_output + alpha * (new_input - prev_output);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/math.h
+++ b/upkie/cpp/utils/math.h
@@ -6,7 +6,7 @@
 #include <cstdint>
 
 //! Utility functions.
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 //! True if and only if \p divisor divides \p number.
 inline bool divides(uint32_t number, uint32_t divisor) {
@@ -17,4 +17,4 @@ inline bool divides(uint32_t number, uint32_t divisor) {
   return (number == k * divisor);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/random_string.h
+++ b/upkie/cpp/utils/random_string.h
@@ -7,7 +7,7 @@
 #include <random>
 #include <string>
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 /*! Generate a random string.
  *
@@ -28,4 +28,4 @@ inline std::string random_string(unsigned length = 16) {
   return alphanum.substr(0, length);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/realtime.h
+++ b/upkie/cpp/utils/realtime.h
@@ -12,7 +12,7 @@
 #include <spdlog/spdlog.h>
 #endif
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 /*! Set the current thread to run on a given CPU core.
  *
@@ -64,4 +64,4 @@ inline bool lock_memory() {
   return (::mlockall(MCL_CURRENT | MCL_FUTURE) >= 0);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/tests/SynchronousClockTest.cpp
+++ b/upkie/cpp/utils/tests/SynchronousClockTest.cpp
@@ -4,7 +4,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/utils/SynchronousClock.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(SynchronousClock, GetsSomeSleep) {
   SynchronousClock clock(10 /* Hz */);  // 100 ms loop
@@ -29,4 +29,4 @@ TEST(SynchronousClock, NoMarginWhenSkippingCycles) {
   ASSERT_DOUBLE_EQ(clock.slack(), 0.);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/tests/low_pass_filter_test.cpp
+++ b/upkie/cpp/utils/tests/low_pass_filter_test.cpp
@@ -7,7 +7,7 @@
 #include "gtest/gtest.h"
 #include "upkie/cpp/exceptions/FilterError.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(InlineLowPassFilter, InformationLoss) {
   const double prev_output = 0.0;
@@ -29,4 +29,4 @@ TEST(InlineLowPassFilter, Converges) {
   ASSERT_LT(output, target);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/tests/math_test.cpp
+++ b/upkie/cpp/utils/tests/math_test.cpp
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(Math, Divides) {
   ASSERT_FALSE(divides(1000000u, 0u));
@@ -13,4 +13,4 @@ TEST(Math, Divides) {
   ASSERT_TRUE(divides(100u, 20u));
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/tests/random_string_test.cpp
+++ b/upkie/cpp/utils/tests/random_string_test.cpp
@@ -7,7 +7,7 @@
 
 #include "gtest/gtest.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(RandomString, HasCorrectLength) {
   ASSERT_EQ(random_string(16).size(), 16);
@@ -26,4 +26,4 @@ TEST(RandomString, DoesNotRepeat) {
   ASSERT_NE(first_string, second_string);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/tests/realtime_test.cpp
+++ b/upkie/cpp/utils/tests/realtime_test.cpp
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(Realtime, ConfigureCPU) { ASSERT_NO_THROW(configure_cpu(0)); }
 
@@ -14,4 +14,4 @@ TEST(Realtime, ConfigureScheduler) {
   ASSERT_THROW(configure_scheduler(priority), std::runtime_error);
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/version.h
+++ b/upkie/cpp/version.h
@@ -4,7 +4,7 @@
 
 #include <string>
 
-namespace upkie {
+namespace upkie::cpp {
 
 constexpr std::string_view kVersion = "4.0.0";
 

--- a/upkie/utils/tests/datetime_now_string_test.cpp
+++ b/upkie/utils/tests/datetime_now_string_test.cpp
@@ -7,7 +7,7 @@
 
 #include "gtest/gtest.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(DatetimeNowString, IsADatetimeString) {
   auto now = datetime_now_string();
@@ -17,4 +17,4 @@ TEST(DatetimeNowString, IsADatetimeString) {
   ASSERT_EQ(now[10], '_');
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils

--- a/upkie/utils/tests/get_log_path_test.cpp
+++ b/upkie/utils/tests/get_log_path_test.cpp
@@ -7,7 +7,7 @@
 
 #include "gtest/gtest.h"
 
-namespace upkie::utils {
+namespace upkie::cpp::utils {
 
 TEST(GetLogPath, StartsWithLogdir) {
   const std::string path = get_log_path("log_dir", "spine_name");
@@ -20,4 +20,4 @@ TEST(GetLogPath, EndsWithMpack) {
   ASSERT_EQ(path.rfind(suffix), path.size() - suffix.size());
 }
 
-}  // namespace upkie::utils
+}  // namespace upkie::cpp::utils


### PR DESCRIPTION
@ubgk for your information. The rationale for this is roughly:

- Pro:
    - Documentation is better organized (avoids mixing C++ alongside Python)
    - Namespaces, includes and file paths all match
- Con:
    - Longer namespace strings

