### PR TITLE
Rename and document sim observations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,14 @@ jobs:
     ci_success:
         name: "CI success"
         runs-on: ubuntu-latest
-        needs: [artifacts, build_linux, build_darwin_arm64, build_darwin_x86, coverage, lint, test]
+        needs:
+            - artifacts
+            - build_darwin_arm64
+            - build_darwin_x86
+            - build_linux
+            - build_raspi
+            - coverage
+            - lint
+            - test
         steps:
             - run: echo "CI workflow completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,9 +213,9 @@ jobs:
               run: |
                   tools/bazelisk test --compilation_mode=fastbuild //...
 
-    bazel_success:
-        name: "Bazel success"
+    ci_success:
+        name: "CI success"
         runs-on: ubuntu-latest
         needs: [artifacts, build_linux, build_darwin_arm64, build_darwin_x86, coverage, lint, test]
         steps:
-            - run: echo "Bazel workflow completed successfully"
+            - run: echo "CI workflow completed successfully"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- actuation: Log groundtruth quantities to observation["groundtruth"]
+- actuation: Log simulation groundtruth to `sim`
+- BulletInterface: Move simulation body poses to `sim.bodies`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- BulletInterface: Report velocity of the base link in groundtruth
 - BulletInterface: Torque control noise to joint-property configuration
 - BulletInterface: Torque measurement noise to joint-property configuration
 - BulletInterface: Uncertainty on IMU accelerometer and gyroscope measurements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - examples: Simulation with joint friction
 - examples: Simulation with sensor noise
 
+### Changed
+
+- actuation: Log groundtruth quantities to observation["groundtruth"]
+
 ### Fixed
 
 - BulletInterface: Fix application of external forces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - BulletInterface: Report velocity of the base link in groundtruth
 - BulletInterface: Torque control noise to joint-property configuration

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Copyright 2023-2024 Inria
 
 # Hostname or IP address of the Raspberry Pi Uses the value from the UPKIE_NAME
-# environment variable, if defined. Valid usage: ``make upload UPKIE_NAME=foo``
+# environment variable, if defined. Valid usage: `make upload UPKIE_NAME=foo`
 REMOTE = ${UPKIE_NAME}
 
 # Project name needs to match the one in WORKSPACE
@@ -66,7 +66,7 @@ run_bullet_spine:  ## run the Bullet simulation spine
 set_date:
 	ssh $(REMOTE) sudo date -s "$(CURDATE)"
 
-# Running ``raspunzel -s`` can create __pycache__ directories owned by root
+# Running `raspunzel -s` can create __pycache__ directories owned by root
 # that rsync is not allowed to remove. We therefore give permissions first.
 .PHONY: upload
 upload: check_upkie_name build set_date  ## upload built targets to the Raspberry Pi

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -2,7 +2,7 @@
 
 ## From newbie to sourcie
 
-While newcomers will likely run `start_simulation.sh` and import the ``upkie`` package in Python, as you get acquainted with the robot and develop your own agents (by forking [upkie/new\_agent](https://github.com/upkie/new_agent)), you may want to contribute some features back to the upstream repository. Here is a short guide on compiling from source to do that.
+While newcomers will likely run `start_simulation.sh` and import the `upkie` package in Python, as you get acquainted with the robot and develop your own agents (by forking [upkie/new\_agent](https://github.com/upkie/new_agent)), you may want to contribute some features back to the upstream repository. Here is a short guide on compiling from source to do that.
 
 ### Build environment setup {#setup-build}
 
@@ -12,7 +12,7 @@ First, setup a build environment following the instructions for your system:
 - [macOs](https://github.com/orgs/upkie/discussions/159)
 - [Ubuntu](https://github.com/orgs/upkie/discussions/101)
 
-To upload software to the robot, you will also need to define the ``UPKIE_NAME`` environment variable. Assuming the hostname of your Upkie is "michel-strogoff", for example, you can add the following to your shell configuration file:
+To upload software to the robot, you will also need to define the `UPKIE_NAME` environment variable. Assuming the hostname of your Upkie is "michel-strogoff", for example, you can add the following to your shell configuration file:
 
 ```
 export UPKIE_NAME="michel-strogoff"
@@ -30,7 +30,7 @@ Once the simulation builds and runs successfully, move onto building the [pi3hat
 
 ### Using the local Python module
 
-If you make changes to the ``upkie`` Python module, you will want to make Python import your local version rather than the one installed from conda-forge or PyPI. There are two ways to do so. One of them is to re-install the package locally, using ``pip`` from the root of (your local copy of) the repository:
+If you make changes to the `upkie` Python module, you will want to make Python import your local version rather than the one installed from conda-forge or PyPI. There are two ways to do so. One of them is to re-install the package locally, using `pip` from the root of (your local copy of) the repository:
 
 ```
 cd upkie

--- a/docs/gym-environments.md
+++ b/docs/gym-environments.md
@@ -1,10 +1,10 @@
 # Gym environments {#environments}
 
-Upkie has reinforcement learning environments following the [Gymnasium](https://gymnasium.farama.org/) API. All of them are single-threaded and run as-is in both simulation and on real robots. Each environment has its own observation and action spaces, but all of them provide access to full spine observation via ``info`` dictionaries. See \ref observations for details.
+Upkie has reinforcement learning environments following the [Gymnasium](https://gymnasium.farama.org/) API. All of them are single-threaded and run as-is in both simulation and on real robots. Each environment has its own observation and action spaces, but all of them provide access to full spine observation via `info` dictionaries. See \ref observations for details.
 
 ## Ground velocity {#ground-velocity-env}
 
-In the ``UpkieGroundVelocity`` environment, Upkie keeps its legs straight and actions only affect wheel velocities. This environment is used for instance by the [MPC balancer](https://github.com/upkie/mpc_balancer/) and [PPO balancer](https://github.com/upkie/ppo_balancer) agents. Its action consists of a 1D vector containing the commanded ground velocity, which is then internally converted to wheel velocity commands.
+In the `UpkieGroundVelocity` environment, Upkie keeps its legs straight and actions only affect wheel velocities. This environment is used for instance by the [MPC balancer](https://github.com/upkie/mpc_balancer/) and [PPO balancer](https://github.com/upkie/ppo_balancer) agents. Its action consists of a 1D vector containing the commanded ground velocity, which is then internally converted to wheel velocity commands.
 
 \f[
 \begin{align*}
@@ -22,7 +22,7 @@ Check out the [UpkieGroundVelocity](\ref upkie.envs.upkie_ground_velocity.UpkieG
 
 ## Servos {#servos-env}
 
-The ``UpkieServos`` environment has dictionary observation and action spaces. Observation dictionaries return position, velocity and torque for each servo. Action dictionaries specify target positions, target velocities and feedforward torque commands that are directly sent to the moteus controllers. Each motor controller will then apply a standard control law with feedforward torque and position-velocity feedback:
+The `UpkieServos` environment has dictionary observation and action spaces. Observation dictionaries return position, velocity and torque for each servo. Action dictionaries specify target positions, target velocities and feedforward torque commands that are directly sent to the moteus controllers. Each motor controller will then apply a standard control law with feedforward torque and position-velocity feedback:
 
 \f[
 \begin{align*}

--- a/docs/observations.md
+++ b/docs/observations.md
@@ -1,6 +1,6 @@
 # Observations {#observations}
 
-Spines compute observation dictionaries from [sensor measurements](\ref sensors) by applying *observers* one after the other in a sequence called the *observer pipeline*. This page lists the outputs of available observers, using shorthands ``a.b.c`` for nested dictionary keys ``observation["a"]["b"]["c"]``.
+Spines compute observation dictionaries from [sensor measurements](\ref sensors) by applying *observers* one after the other in a sequence called the *observer pipeline*. This page lists the outputs of available observers, using shorthands `a.b.c` for nested dictionary keys `observation["a"]["b"]["c"]`.
 
 ## IMU observations
 
@@ -34,7 +34,7 @@ R_{WA} = \begin{bmatrix}
 
 | Observation key | Description |
 |-----------------|-------------|
-| `servo.X` | Observations for servo ``X`` in the servo layout |
+| `servo.X` | Observations for servo `X` in the servo layout |
 | `servo.X.position` | Angle between the stator and the rotor in [rad] |
 | `servo.X.torque` | Joint torque in [N m] |
 | `servo.X.velocity` | Angular velocity of the rotor w.r.t. stator in rotor, in [rad] / [s] |

--- a/docs/observations.md
+++ b/docs/observations.md
@@ -8,7 +8,7 @@ Spines compute observation dictionaries from [sensor measurements](\ref sensors)
 |-----------------|-------------|
 | `imu.angular_velocity` | Body angular velocity of the IMU frame in [rad] / [s] |
 | `imu.linear_acceleration` | Linear acceleration of the IMU, with gravity filtered out, in [m] / [s]² |
-| `imu.orientation` | Unit quaternion (``qw``, ``qx``, ``qy``, ``qz``) of the orientation from the IMU frame to the [ARS](\ref ars) frame |
+| `imu.orientation` | Unit quaternion (w, x, y, z) of the orientation of the IMU frame in the [ARS](\ref ars) frame |
 | `imu.raw_angular_velocity` | Raw measurement from the gyroscope of the IMU, in [rad] / [s] |
 | `imu.raw_linear_acceleration` | [Proper acceleration](https://en.wikipedia.org/wiki/Accelerometer#Physical_principles) measured by the accelerometer of the IMU, in [m] / [s]² |
 
@@ -93,3 +93,21 @@ observer_pipeline.append_observer(linear_acceleration_history);
 ```
 
 Check out the [HistoryObserver](\ref upkie::cpp::observers::HistoryObserver) API reference for details.
+
+## Simulation groundtruth
+
+Simulation spines may report the additional groundtruth observations:
+
+| Observation key | Description |
+|-----------------|-------------|
+| `groundtruth` | Groundtruth from the simulation |
+| `groundtruth.base` | Positions and velocities of the base frame |
+| `groundtruth.base.position` | Position of the base frame in the world frame, in [m] |
+| `groundtruth.base.orientation` | Unit quaternion (q, x, y, z) of the orientation of the base frame in the world frame |
+| `groundtruth.base.linear_velocity` | Linear velocity from base to world in world, in [m] / [s] |
+| `groundtruth.base.angular_velocity` | Angular velocity from base to world in world, in [rad] / [s] |
+| `groundtruth.imu` | Non-observables related to the IMU |
+| `groundtruth.imu.linear_velocity` | Linear velocity of the IMU frame in the world frame, in [m] / [s] |
+| `groundtruth.YYY` | Positions and velocities of the extra body YYY |
+| `groundtruth.YYY.position` | Position of YYY in the world frame, in [m] |
+| `groundtruth.YYY.orientation` | Unit quaternion (q, x, y, z) of the orientation of YYY in the world frame |

--- a/docs/observations.md
+++ b/docs/observations.md
@@ -96,18 +96,28 @@ Check out the [HistoryObserver](\ref upkie::cpp::observers::HistoryObserver) API
 
 ## Simulation groundtruth
 
-Simulation spines may report the additional groundtruth observations:
+Simulation spines may report additional observations:
+
+### Floating base
 
 | Observation key | Description |
 |-----------------|-------------|
-| `groundtruth` | Groundtruth from the simulation |
-| `groundtruth.base` | Positions and velocities of the base frame |
-| `groundtruth.base.position` | Position of the base frame in the world frame, in [m] |
-| `groundtruth.base.orientation` | Unit quaternion (q, x, y, z) of the orientation of the base frame in the world frame |
-| `groundtruth.base.linear_velocity` | Linear velocity from base to world in world, in [m] / [s] |
-| `groundtruth.base.angular_velocity` | Angular velocity from base to world in world, in [rad] / [s] |
-| `groundtruth.imu` | Non-observables related to the IMU |
-| `groundtruth.imu.linear_velocity` | Linear velocity of the IMU frame in the world frame, in [m] / [s] |
-| `groundtruth.YYY` | Positions and velocities of the extra body YYY |
-| `groundtruth.YYY.position` | Position of YYY in the world frame, in [m] |
-| `groundtruth.YYY.orientation` | Unit quaternion (q, x, y, z) of the orientation of YYY in the world frame |
+| `sim.base` | Positions and velocities of the base frame |
+| `sim.base.position` | Position of the base frame in the world frame, in [m] |
+| `sim.base.orientation` | Unit quaternion (q, x, y, z) of the orientation of the base frame in the world frame |
+| `sim.base.linear_velocity` | Linear velocity from base to world in world, in [m] / [s] |
+| `sim.base.angular_velocity` | Angular velocity from base to world in world, in [rad] / [s] |
+
+### IMU
+
+| Observation key | Description |
+|-----------------|-------------|
+| `sim.imu` | Non-observables related to the IMU |
+| `sim.imu.linear_velocity` | Linear velocity of the IMU frame in the world frame, in [m] / [s] |
+
+### Rigid bodies
+
+| `sim.bodies` | Coordinates of rigid bodies in the world frame |
+| `sim.bodies.YYY` | Positions and velocities of the extra body YYY |
+| `sim.bodies.YYY.position` | Position of YYY in the world frame, in [m] |
+| `sim.bodies.YYY.orientation` | Unit quaternion (q, x, y, z) of the orientation of YYY in the world frame |

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -13,7 +13,7 @@ These raw measurements are converted onboard by an unscented Kalman filter (base
 - Body angular velocity of the IMU frame, after bias reduction
 - Orientation of the IMU frame in the ARS frame
 
-These observations are exposed by the spine in ``observation["imu"]``. Check out [ImuData](\ref upkie::cpp::actuation::ImuData) and [Observations](\ref observations) for more details.
+These observations are exposed by the spine in `observation["imu"]`. Check out [ImuData](\ref upkie::cpp::actuation::ImuData) and [Observations](\ref observations) for more details.
 
 ## Actuators
 
@@ -23,4 +23,4 @@ Actuators on the robot are [qdd100 beta 3](https://mjbots.com/products/qdd100-be
 - Joint velocity, obtained by filtering joint angle measurements (not a direct measurement)
 - Joint torque, estimated from sensed phase currents (with a model that includes [stator magnetic saturation](https://jpieper.com/2020/07/31/dealing-with-stator-magnetic-saturation/)
 
-These measurements are exposed by the spine in ``observation["servos"]``. Check out [Observations](\ref observations) for more details.
+These measurements are exposed by the spine in `observation["servos"]`. Check out [Observations](\ref observations) for more details.

--- a/docs/spines.md
+++ b/docs/spines.md
@@ -48,7 +48,7 @@ To build and run the simulation from source, [setup your build environment](\ref
 ./tools/bazelisk run //spines:bullet_spine -- --show
 ```
 
-Bazel is the build system used in Upkie for spines. Check out simulation options by appending the help flag ``-h`` to the above command.
+Bazel is the build system used in Upkie for spines. Check out simulation options by appending the help flag `-h` to the above command.
 
 ## Real-robot spines {#real-robot-spines}
 

--- a/examples/model_predictive_control.py
+++ b/examples/model_predictive_control.py
@@ -21,7 +21,7 @@ try:
     from qpmpc.systems import WheeledInvertedPendulum
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "This example uses qpmpc: ``[conda|pip] install qpmpc``"
+        "This example uses qpmpc: `[conda|pip] install qpmpc`"
     )
 
 upkie.envs.register()

--- a/pid_balancer/main_bullet.py
+++ b/pid_balancer/main_bullet.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 
     if "-opt" not in spine_path or "-fastbuild" in spine_path:
         raise CompilationModeError(
-            "This example is meant to be called by ``bazel run -c opt`` "
+            "This example is meant to be called by `bazel run -c opt` "
             "so that the simulator performs well, but it seems the "
             'compilation mode is "fastbuild"? Go to the code and comment out '
             "this check if you know what you are doing :)"

--- a/pid_balancer/wheel_controller.py
+++ b/pid_balancer/wheel_controller.py
@@ -7,7 +7,7 @@
 
 """Keep the robot up using its wheels."""
 
-from typing import List, Optional, Tuple
+from typing import Tuple
 
 import gin
 import numpy as np
@@ -431,9 +431,9 @@ class WheelController:
         )
 
         # Non-minimum phase trick: as per control theory's book, the proper
-        # feedforward velocity should be ``+self.target_ground_velocity``.
+        # feedforward velocity should be `+self.target_ground_velocity`.
         # However, it is with resolute purpose that it sends
-        # ``-self.target_ground_velocity`` instead!
+        # `-self.target_ground_velocity` instead!
         #
         # Try both on the robot, you will see the difference :)
         #
@@ -447,9 +447,9 @@ class WheelController:
         # velocity (or only a fraction of it, although 100% seems to do a good
         # job), Upkie will immediately start executing the desired non-minimum
         # phase behavior. The error will then grow and the integrator catch up
-        # so that ``upkie_trick_velocity - self.integral_error_velocity``
-        # converges to its proper steady state value (the same value ``0 -
-        # self.integral_error_velocity`` would have converged to if we had no
+        # so that `upkie_trick_velocity - self.integral_error_velocity``
+        # converges to its proper steady state value (the same value `0 -
+        # self.integral_error_velocity` would have converged to if we had no
         # feedforward).
         #
         # Unconvinced? Try it on the robot. You will feel Upkie's trick ;)

--- a/tools/logs/Makefile
+++ b/tools/logs/Makefile
@@ -3,8 +3,8 @@
 #
 # Convenience Makefile to synchronize Upkie log files
 #
-# Put this Makefile in the directory to synchronize and run ``make download``
-# to download the latest logs from the robot.
+# Put this Makefile in the directory to synchronize and run `make download` to
+# download the latest logs from the robot.
 
 # Hostname or IP address of the Raspberry Pi Uses the value from the UPKIE_NAME
 # environment variable, if defined.

--- a/tools/power_dist_check
+++ b/tools/power_dist_check
@@ -24,7 +24,7 @@ TYPECODES = {"int8": 0, "int16": 1, "int32": 2, "f32": 3}
 class Stream:
     """Stream class to decode data fields.
 
-    Source: ``utils/decode_can_frame.py`` in
+    Source: `utils/decode_can_frame.py` in
     [mjbots/moteus](https://github.com/mjbots/moteus/)."""
 
     def __init__(self, data):

--- a/tools/setup/setup_wifi_ap.py
+++ b/tools/setup/setup_wifi_ap.py
@@ -16,7 +16,7 @@
 """Set up a Raspberry Pi 4b to operate a Wi-Fi access point.
 
 The base operating system should already be installed. This script is intended
-to be run as root, like: ``sudo ./setup-wifi-ap.py``.
+to be run as root, like: `sudo ./setup-wifi-ap.py`.
 """
 
 import argparse

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -193,18 +193,19 @@ void BulletInterface::reset_joint_properties() {
 void BulletInterface::observe(Dictionary& observation) const {
   Interface::observe_imu(observation);
 
-  Dictionary& monitor = observation("bullet");
-  monitor("imu")("linear_velocity") = imu_data_.linear_velocity_imu_in_world;
+  Dictionary& groundtruth = observation("groundtruth");
+  groundtruth("imu")("linear_velocity") =
+      imu_data_.linear_velocity_imu_in_world;
   for (const auto& link_name : params_.monitor_contacts) {
-    monitor("contact")(link_name)("num_contact_points") =
+    groundtruth("contact")(link_name)("num_contact_points") =
         contact_data_.at(link_name).num_contact_points;
   }
 
-  // Observe the base state
+  // Observe base pose
   Eigen::Matrix4d T = transform_base_to_world();
-  monitor("base")("position") =
+  groundtruth("base")("position") =
       Eigen::Vector3d(T(0, 3), T(1, 3), T(2, 3));  // [m]
-  monitor("base")("orientation") =
+  groundtruth("base")("orientation") =
       Eigen::Quaterniond(T.block<3, 3>(0, 0));  // [w, x, y, z]
 
   // Observe the environnement urdf states
@@ -212,9 +213,9 @@ void BulletInterface::observe(Dictionary& observation) const {
     const auto& body_name = key_child.first;
     const auto& body_id = key_child.second;
     Eigen::Matrix4d T = transform_body_to_world(body_id);
-    monitor(body_name)("position") =
+    groundtruth(body_name)("position") =
         Eigen::Vector3d(T(0, 3), T(1, 3), T(2, 3));  // [m]
-    monitor(body_name)("orientation") =
+    groundtruth(body_name)("orientation") =
         Eigen::Quaterniond(T.block<3, 3>(0, 0));  // [w, x, y, z]
   }
 }

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -208,6 +208,17 @@ void BulletInterface::observe(Dictionary& observation) const {
   groundtruth("base")("orientation") =
       Eigen::Quaterniond(T.block<3, 3>(0, 0));  // [w, x, y, z]
 
+  // Observe base velocity
+  btVector3 linear_velocity_base_to_world_in_world;
+  btVector3 angular_velocity_base_to_world_in_world;
+  bullet_.getBaseVelocity(robot_, linear_velocity_base_to_world_in_world,
+                          angular_velocity_base_to_world_in_world);
+  Eigen::Vector3d v = eigen_from_bullet(linear_velocity_base_to_world_in_world);
+  Eigen::Vector3d omega =
+      eigen_from_bullet(angular_velocity_base_to_world_in_world);
+  groundtruth("base")("linear_velocity") = v;       // [m] / [s]
+  groundtruth("base")("angular_velocity") = omega;  // [rad] / [s]
+
   // Observe the environnement urdf states
   for (const auto& key_child : body_names) {
     const auto& body_name = key_child.first;

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -130,11 +130,11 @@ class BulletInterface : public Interface {
      *
      * A path from the root of the Bazel workspace works. For instance, use
      * "models/upkie_description/urdf/upkie.urdf" to load the URDF from Bazel
-     * data such as ``data = ["//models/upkie_description"]``.
+     * data such as `data = ["//models/upkie_description"]`.
      *
      * For external targets, add the "external/" prefix. For instance, use
      * "external/upkie_description/urdf/upkie.urdf" to load the URDF from Bazel
-     * data loaded from a dependency: ``data = ["@upkie_description"]``.
+     * data loaded from a dependency: `data = ["@upkie_description"]`.
      */
     std::string robot_urdf_path;
 

--- a/upkie/cpp/actuation/tests/BulletInterfaceEnvBodies.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceEnvBodies.cpp
@@ -71,31 +71,23 @@ TEST_F(BulletInterfaceEnvBodies, MonitorEnvBodies) {
   interface_->observe(observation);
 
   ASSERT_TRUE(observation.has("sim"));
-  ASSERT_TRUE(observation("sim").has("plane"));
-  ASSERT_TRUE(observation("sim")("plane").has("position"));
-  ASSERT_TRUE(observation("sim")("plane").has("orientation"));
+  ASSERT_TRUE(observation("sim").has("bodies"));
+
+  const auto& bodies = observation("sim")("bodies");
+  ASSERT_TRUE(bodies.has("plane"));
+  ASSERT_TRUE(bodies("plane").has("position"));
+  ASSERT_TRUE(bodies("plane").has("orientation"));
 
   // Plane was loaded at the origin
-  ASSERT_EQ(observation("sim")("plane").get<Eigen::Vector3d>("position").x(),
-            0.);
-  ASSERT_EQ(observation("sim")("plane").get<Eigen::Vector3d>("position").y(),
-            0.);
-  ASSERT_EQ(observation("sim")("plane").get<Eigen::Vector3d>("position").z(),
-            0.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Vector3d>("position").x(), 0.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Vector3d>("position").y(), 0.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Vector3d>("position").z(), 0.);
 
   // Plane orientation is the identity
-  ASSERT_EQ(
-      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").w(),
-      1.);
-  ASSERT_EQ(
-      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").x(),
-      0.);
-  ASSERT_EQ(
-      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").y(),
-      0.);
-  ASSERT_EQ(
-      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").z(),
-      0.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Quaterniond>("orientation").w(), 1.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Quaterniond>("orientation").x(), 0.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Quaterniond>("orientation").y(), 0.);
+  ASSERT_EQ(bodies("plane").get<Eigen::Quaterniond>("orientation").z(), 0.);
 }
 
 }  // namespace upkie::cpp::actuation

--- a/upkie/cpp/actuation/tests/BulletInterfaceEnvBodies.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceEnvBodies.cpp
@@ -70,31 +70,31 @@ TEST_F(BulletInterfaceEnvBodies, MonitorEnvBodies) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("bullet"));
-  ASSERT_TRUE(observation("bullet").has("plane"));
-  ASSERT_TRUE(observation("bullet")("plane").has("position"));
-  ASSERT_TRUE(observation("bullet")("plane").has("orientation"));
+  ASSERT_TRUE(observation.has("sim"));
+  ASSERT_TRUE(observation("sim").has("plane"));
+  ASSERT_TRUE(observation("sim")("plane").has("position"));
+  ASSERT_TRUE(observation("sim")("plane").has("orientation"));
 
   // Plane was loaded at the origin
-  ASSERT_EQ(observation("bullet")("plane").get<Eigen::Vector3d>("position").x(),
+  ASSERT_EQ(observation("sim")("plane").get<Eigen::Vector3d>("position").x(),
             0.);
-  ASSERT_EQ(observation("bullet")("plane").get<Eigen::Vector3d>("position").y(),
+  ASSERT_EQ(observation("sim")("plane").get<Eigen::Vector3d>("position").y(),
             0.);
-  ASSERT_EQ(observation("bullet")("plane").get<Eigen::Vector3d>("position").z(),
+  ASSERT_EQ(observation("sim")("plane").get<Eigen::Vector3d>("position").z(),
             0.);
 
   // Plane orientation is the identity
   ASSERT_EQ(
-      observation("bullet")("plane").get<Eigen::Quaterniond>("orientation").w(),
+      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").w(),
       1.);
   ASSERT_EQ(
-      observation("bullet")("plane").get<Eigen::Quaterniond>("orientation").x(),
+      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").x(),
       0.);
   ASSERT_EQ(
-      observation("bullet")("plane").get<Eigen::Quaterniond>("orientation").y(),
+      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").y(),
       0.);
   ASSERT_EQ(
-      observation("bullet")("plane").get<Eigen::Quaterniond>("orientation").z(),
+      observation("sim")("plane").get<Eigen::Quaterniond>("orientation").z(),
       0.);
 }
 

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -291,14 +291,14 @@ TEST_F(BulletInterfaceTest, MonitorContacts) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("groundtruth"));
-  ASSERT_TRUE(observation("groundtruth").has("contact"));
-  ASSERT_TRUE(observation("groundtruth")("contact").has("left_wheel_tire"));
-  ASSERT_TRUE(observation("groundtruth")("contact").has("right_wheel_tire"));
-  ASSERT_EQ(observation("groundtruth")("contact")("left_wheel_tire")
+  ASSERT_TRUE(observation.has("sim"));
+  ASSERT_TRUE(observation("sim").has("contact"));
+  ASSERT_TRUE(observation("sim")("contact").has("left_wheel_tire"));
+  ASSERT_TRUE(observation("sim")("contact").has("right_wheel_tire"));
+  ASSERT_EQ(observation("sim")("contact")("left_wheel_tire")
                 .get<int>("num_contact_points"),
             0);
-  ASSERT_EQ(observation("groundtruth")("contact")("right_wheel_tire")
+  ASSERT_EQ(observation("sim")("contact")("right_wheel_tire")
                 .get<int>("num_contact_points"),
             0);
 }
@@ -312,11 +312,11 @@ TEST_F(BulletInterfaceTest, MonitorIMU) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("groundtruth"));
-  ASSERT_TRUE(observation("groundtruth").has("imu"));
-  ASSERT_TRUE(observation("groundtruth")("imu").has("linear_velocity"));
+  ASSERT_TRUE(observation.has("sim"));
+  ASSERT_TRUE(observation("sim").has("imu"));
+  ASSERT_TRUE(observation("sim")("imu").has("linear_velocity"));
   Eigen::Vector3d linear_velocity_imu_in_imu =
-      observation("groundtruth")("imu")("linear_velocity");
+      observation("sim")("imu")("linear_velocity");
   ASSERT_DOUBLE_EQ(linear_velocity_imu_in_imu.z(), -bullet::kGravity * dt_);
 }
 
@@ -329,11 +329,10 @@ TEST_F(BulletInterfaceTest, MonitorBaseState) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("groundtruth"));
-  ASSERT_TRUE(observation("groundtruth").has("base"));
-  ASSERT_TRUE(observation("groundtruth")("base").has("position"));
-  Eigen::Vector3d base_position =
-      observation("groundtruth")("base")("position");
+  ASSERT_TRUE(observation.has("sim"));
+  ASSERT_TRUE(observation("sim").has("base"));
+  ASSERT_TRUE(observation("sim")("base").has("position"));
+  Eigen::Vector3d base_position = observation("sim")("base")("position");
 
   ASSERT_NEAR(base_position.x(), 0.0, 1e-20);
   ASSERT_NEAR(base_position.y(), 0.0, 1e-20);
@@ -345,9 +344,9 @@ TEST_F(BulletInterfaceTest, MonitorBaseState) {
   ASSERT_NEAR(base_position.z(), 3 * -bullet::kGravity * std::pow(dt_, 2.0),
               1e-6);
 
-  ASSERT_TRUE(observation("groundtruth")("base").has("orientation"));
+  ASSERT_TRUE(observation("sim")("base").has("orientation"));
   Eigen::Quaterniond base_orientation =
-      observation("groundtruth")("base")("orientation");
+      observation("sim")("base")("orientation");
 
   // Rotation vector should be practically zero
   ASSERT_DOUBLE_EQ(base_orientation.w(), 1.0);

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -291,14 +291,14 @@ TEST_F(BulletInterfaceTest, MonitorContacts) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("bullet"));
-  ASSERT_TRUE(observation("bullet").has("contact"));
-  ASSERT_TRUE(observation("bullet")("contact").has("left_wheel_tire"));
-  ASSERT_TRUE(observation("bullet")("contact").has("right_wheel_tire"));
-  ASSERT_EQ(observation("bullet")("contact")("left_wheel_tire")
+  ASSERT_TRUE(observation.has("groundtruth"));
+  ASSERT_TRUE(observation("groundtruth").has("contact"));
+  ASSERT_TRUE(observation("groundtruth")("contact").has("left_wheel_tire"));
+  ASSERT_TRUE(observation("groundtruth")("contact").has("right_wheel_tire"));
+  ASSERT_EQ(observation("groundtruth")("contact")("left_wheel_tire")
                 .get<int>("num_contact_points"),
             0);
-  ASSERT_EQ(observation("bullet")("contact")("right_wheel_tire")
+  ASSERT_EQ(observation("groundtruth")("contact")("right_wheel_tire")
                 .get<int>("num_contact_points"),
             0);
 }
@@ -312,11 +312,11 @@ TEST_F(BulletInterfaceTest, MonitorIMU) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("bullet"));
-  ASSERT_TRUE(observation("bullet").has("imu"));
-  ASSERT_TRUE(observation("bullet")("imu").has("linear_velocity"));
+  ASSERT_TRUE(observation.has("groundtruth"));
+  ASSERT_TRUE(observation("groundtruth").has("imu"));
+  ASSERT_TRUE(observation("groundtruth")("imu").has("linear_velocity"));
   Eigen::Vector3d linear_velocity_imu_in_imu =
-      observation("bullet")("imu")("linear_velocity");
+      observation("groundtruth")("imu")("linear_velocity");
   ASSERT_DOUBLE_EQ(linear_velocity_imu_in_imu.z(), -bullet::kGravity * dt_);
 }
 
@@ -329,10 +329,11 @@ TEST_F(BulletInterfaceTest, MonitorBaseState) {
   interface_->cycle([](const moteus::Output& output) {});
   interface_->observe(observation);
 
-  ASSERT_TRUE(observation.has("bullet"));
-  ASSERT_TRUE(observation("bullet").has("base"));
-  ASSERT_TRUE(observation("bullet")("base").has("position"));
-  Eigen::Vector3d base_position = observation("bullet")("base")("position");
+  ASSERT_TRUE(observation.has("groundtruth"));
+  ASSERT_TRUE(observation("groundtruth").has("base"));
+  ASSERT_TRUE(observation("groundtruth")("base").has("position"));
+  Eigen::Vector3d base_position =
+      observation("groundtruth")("base")("position");
 
   ASSERT_NEAR(base_position.x(), 0.0, 1e-20);
   ASSERT_NEAR(base_position.y(), 0.0, 1e-20);
@@ -344,9 +345,9 @@ TEST_F(BulletInterfaceTest, MonitorBaseState) {
   ASSERT_NEAR(base_position.z(), 3 * -bullet::kGravity * std::pow(dt_, 2.0),
               1e-6);
 
-  ASSERT_TRUE(observation("bullet")("base").has("orientation"));
+  ASSERT_TRUE(observation("groundtruth")("base").has("orientation"));
   Eigen::Quaterniond base_orientation =
-      observation("bullet")("base")("orientation");
+      observation("groundtruth")("base")("orientation");
 
   // Rotation vector should be practically zero
   ASSERT_DOUBLE_EQ(base_orientation.w(), 1.0);

--- a/upkie/cpp/observers/BaseOrientation.h
+++ b/upkie/cpp/observers/BaseOrientation.h
@@ -18,8 +18,8 @@ using palimpsest::Dictionary;
 /*! Get the orientation of the base frame with respect to the world frame.
 
  * \param quat_imu_in_ars Quaternion representing the rotation matrix from the
- *     IMU frame to the  attitude reference system (ARS) frame, in ``[w, x, y,
- *     z]`` format.
+ *     IMU frame to the  attitude reference system (ARS) frame, in `[w, x, y,
+ *     z]` format.
  * \param rotation_base_to_imu Rotation matrix from the base frame to the IMU
  *     frame. When not specified, the default Upkie mounting orientation is
  *     used.
@@ -67,9 +67,9 @@ inline Eigen::Matrix3d compute_base_orientation_from_imu(
  *     the frame.
  *
  * \note Angle is positive in the trigonometric sense (CCW positive, CW
- * negative) in the heading-vertical plane directed by the lateral vector,
- * which is ``(x)`` in the above schematic (pointing away) and not ``(.)``
- * (poiting from screen to the reader).
+ *     negative) in the heading-vertical plane directed by the lateral vector,
+ *     which is `(x)` in the above schematic (pointing away) and not `(.)`
+ *     (pointing from screen to the reader).
  */
 inline double compute_pitch_frame_in_parent(
     const Eigen::Matrix3d& orientation_frame_in_parent) {

--- a/upkie/cpp/sensors/Sensor.h
+++ b/upkie/cpp/sensors/Sensor.h
@@ -25,7 +25,7 @@ class Sensor {
 
   /*! Prefix of output in the observation dictionary.
    *
-   * This prefix is looked up by the spine to feed ``observation(prefix)`` to
+   * This prefix is looked up by the spine to feed `observation(prefix)` to
    * the \ref write function.
    */
   virtual inline std::string prefix() const noexcept {

--- a/upkie/cpp/spine/AgentInterface.cpp
+++ b/upkie/cpp/spine/AgentInterface.cpp
@@ -48,7 +48,7 @@ AgentInterface::AgentInterface(const std::string& name, size_t size)
           name);
       spdlog::info(
           "If not other spine is running but a previous spine did not exit "
-          "properly, you can run ``sudo rm /dev/shm{}`` to clean this error.",
+          "properly, you can run `sudo rm /dev/shm{}` to clean this error.",
           name);
     } else {
       spdlog::error("Cannot open shared memory file: errno is {}", errno);

--- a/upkie/cpp/spine/AgentInterface.h
+++ b/upkie/cpp/spine/AgentInterface.h
@@ -36,7 +36,7 @@ class AgentInterface {
    * \param[in] name Name of the shared memory file (e.g. "/upkie").
    * \param[in] size Size in bytes.
    *
-   * Shared memory objects are available as files in ``/dev/shm``.
+   * Shared memory objects are available as files in `/dev/shm`.
    */
   AgentInterface(const std::string& name, size_t size);
 

--- a/upkie/cpp/spine/StateMachine.h
+++ b/upkie/cpp/spine/StateMachine.h
@@ -93,14 +93,14 @@ constexpr const char* state_name(const State& state) noexcept {
  *
  * There are three possible events:
  *
- * - ``begin``: beginning of a control cycle,
- * - ``end``: end of a control cycle.
- * - ``SIGINT``: the process received an interrupt signal.
+ * - `begin`: beginning of a control cycle,
+ * - `end`: end of a control cycle.
+ * - `SIGINT`: the process received an interrupt signal.
  *
  * Guards, indicated between brackets, may involve two variables:
  *
- * - ``req``: the current request from the agent.
- * - ``stop_cycles``: the number of stop commands cycled in the current state
+ * - `req`: the current request from the agent.
+ * - `stop_cycles`: the number of stop commands cycled in the current state
  *   (only available in "stop" and "shutdown" states).
  */
 class StateMachine {

--- a/upkie/envs/tests/upkie_envs_test.py
+++ b/upkie/envs/tests/upkie_envs_test.py
@@ -18,7 +18,7 @@ class TestUpkieEnvs(unittest.TestCase):
     def test_registration(self):
         with self.assertRaises(gym.error.NameNotFound):
             # runs in the same test so that we make sure this is executed
-            # before the call to ``register()``
+            # before the call to `register()`
             gym.make("UpkieServos")
         shared_memory = SharedMemory(name=None, size=42, create=True)
         upkie.envs.register()

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -80,7 +80,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             `frequency`.
         \param shm_name Name of shared-memory file to exchange with the spine.
         \param spine_config Additional spine configuration overriding the
-            defaults from ``//config:spine.yaml``. The combined configuration
+            defaults from `//config:spine.yaml`. The combined configuration
             dictionary is sent to the spine at every :func:`reset`.
         \param spine_retries Number of times to try opening the shared-memory
             file to communicate with the spine.
@@ -125,7 +125,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
     @property
     def dt(self) -> Optional[float]:
         """!
-        Regulated period of the control loop in seconds, or ``None`` if there
+        Regulated period of the control loop in seconds, or `None` if there
         is no loop frequency regulation.
         """
         return 1.0 / self.__frequency if self.__frequency is not None else None
@@ -133,7 +133,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
     @property
     def frequency(self) -> Optional[float]:
         """!
-        Regulated frequency of the control loop in Hz, or ``None`` if there is
+        Regulated frequency of the control loop in Hz, or `None` if there is
         no loop frequency regulation.
         """
         return self.__frequency
@@ -160,9 +160,9 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             number generator.
         \param options Currently unused.
         \return
-            - ``observation``: Initial vectorized observation, i.e. an element
-              of the environment's ``observation_space``.
-            - ``info``: Dictionary with auxiliary diagnostic information. For
+            - `observation`: Initial vectorized observation, i.e. an element
+              of the environment's `observation_space`.
+            - `info`: Dictionary with auxiliary diagnostic information. For
               Upkie this is the full observation dictionary sent by the spine.
         """
         super().reset(seed=seed)
@@ -214,17 +214,17 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
 
         \param action Action from the agent.
         \return
-            - ``observation``: Observation of the environment, i.e. an element
-              of its ``observation_space``.
-            - ``reward``: Reward returned after taking the action.
-            - ``terminated``: Whether the agent reached a terminal state,
+            - `observation`: Observation of the environment, i.e. an element
+              of its `observation_space`.
+            - `reward`: Reward returned after taking the action.
+            - `terminated`: Whether the agent reached a terminal state,
               which can be a good or a bad thing. When true, the user needs to
               call :func:`reset()`.
-            - ``truncated'': Whether the episode is reaching max number of
+            - `truncated`: Whether the episode is reaching max number of
               steps. This boolean can signal a premature end of the episode,
               i.e. before a terminal state is reached. When true, the user
               needs to call :func:`reset()`.
-            - ``info``: Dictionary with auxiliary diagnostic information. For
+            - `info`: Dictionary with auxiliary diagnostic information. For
               us this is the full observation dictionary coming from the spine.
         """
         if self.__regulate_frequency:

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -80,7 +80,7 @@ class UpkieGroundVelocity(UpkieBaseEnv):
     </table>
 
     As with all Upkie environments, full observations from the spine (detailed
-    in \ref observations) are also available in the ``info`` dictionary
+    in \ref observations) are also available in the `info` dictionary
     returned by the reset and step functions.
     """
 
@@ -150,7 +150,7 @@ class UpkieGroundVelocity(UpkieBaseEnv):
         \param reward Reward function of the environment.
         \param shm_name Name of shared-memory file.
         \param spine_config Additional spine configuration overriding the
-            defaults from ``//config:spine.yaml``. The combined configuration
+            defaults from `//config:spine.yaml`. The combined configuration
             dictionary is sent to the spine at every :func:`reset`.
         \param wheel_radius Wheel radius in [m].
         """
@@ -227,9 +227,9 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             number generator.
         \param options Currently unused.
         \return
-            - ``observation``: Initial vectorized observation, i.e. an element
-              of the environment's ``observation_space``.
-            - ``info``: Dictionary with auxiliary diagnostic information. For
+            - `observation`: Initial vectorized observation, i.e. an element
+              of the environment's `observation_space`.
+            - `info`: Dictionary with auxiliary diagnostic information. For
               Upkie this is the full observation dictionary sent by the spine.
         """
         return super().reset(seed=seed)

--- a/upkie/envs/upkie_servo_positions.py
+++ b/upkie/envs/upkie_servo_positions.py
@@ -57,7 +57,7 @@ class UpkieServoPositions(UpkieServos):
         \param regulate_frequency Enables loop frequency regulation.
         \param shm_name Name of shared-memory file.
         \param spine_config Additional spine configuration overriding the
-            defaults from ``//config:spine.yaml``. The combined configuration
+            defaults from `//config:spine.yaml`. The combined configuration
             dictionary is sent to the spine at every :func:`reset`.
         """
         super().__init__(

--- a/upkie/envs/upkie_servo_torques.py
+++ b/upkie/envs/upkie_servo_torques.py
@@ -55,7 +55,7 @@ class UpkieServoTorques(UpkieServos):
         \param regulate_frequency Enables loop frequency regulation.
         \param shm_name Name of shared-memory file.
         \param spine_config Additional spine configuration overriding the
-            defaults from ``//config:spine.yaml``. The combined configuration
+            defaults from `//config:spine.yaml`. The combined configuration
             dictionary is sent to the spine at every :func:`reset`.
         """
         super().__init__(

--- a/upkie/envs/upkie_servos.py
+++ b/upkie/envs/upkie_servos.py
@@ -23,27 +23,27 @@ class UpkieServos(UpkieBaseEnv):
 
     The action space is a dictionary with one key for each servo:
 
-    - ``left_hip``: Left hip joint (qdd100)
-    - ``left_hip``: Left knee joint (qdd100)
-    - ``left_hip``: Left wheel joint (mj5208)
-    - ``right_hip``: Right hip joint (qdd100)
-    - ``right_hip``: Right knee joint (qdd100)
-    - ``right_hip``: Right wheel joint (mj5208)
+    - `left_hip`: Left hip joint (qdd100)
+    - `left_hip`: Left knee joint (qdd100)
+    - `left_hip`: Left wheel joint (mj5208)
+    - `right_hip`: Right hip joint (qdd100)
+    - `right_hip`: Right knee joint (qdd100)
+    - `right_hip`: Right wheel joint (mj5208)
 
     The value for each servo dictionary is itself a dictionary with the
     following keys:
 
-    - ``position``: Commanded joint angle \f$\theta^*\f$ in [rad] (NaN to
+    - `position`: Commanded joint angle \f$\theta^*\f$ in [rad] (NaN to
         disable) (required).
-    - ``velocity``: Commanded joint velocity \f$\dot{\theta}^*\f$ in [rad] /
+    - `velocity`: Commanded joint velocity \f$\dot{\theta}^*\f$ in [rad] /
         [s] (required).
-    - ``feedforward_torque``: Feedforward joint torque \f$\tau_{\mathit{ff}}\f$
+    - `feedforward_torque`: Feedforward joint torque \f$\tau_{\mathit{ff}}\f$
         in [N m].
-    - ``kp_scale``: Scaling factor \f$k_{p}^{\mathit{scale}}\f$ applied to the
+    - `kp_scale`: Scaling factor \f$k_{p}^{\mathit{scale}}\f$ applied to the
         position feedback gain, between zero and one.
-    - ``kd_scale``: Scaling factor \f$k_{d}^{\mathit{scale}}\f$ applied to the
+    - `kd_scale`: Scaling factor \f$k_{d}^{\mathit{scale}}\f$ applied to the
         velocity feedback gain, between zero and one.
-    - ``maximum_torque``: Maximum joint torque \f$\tau_{\mathit{max}}\f$
+    - `maximum_torque`: Maximum joint torque \f$\tau_{\mathit{max}}\f$
         (feedforward + feedback) enforced during the whole actuation step, in
         [N m].
 
@@ -74,14 +74,14 @@ class UpkieServos(UpkieBaseEnv):
     The observation space is a dictionary with one key for each servo. The
     value for each key is a dictionary with keys:
 
-    - ``position``: Joint angle in [rad].
-    - ``velocity``: Joint velocity in [rad] / [s].
-    - ``torque``: Joint torque in [N m].
-    - ``temperature``: Servo temperature in degree Celsius.
-    - ``voltage": Power bus voltage of the servo, in [V].
+    - `position`: Joint angle in [rad].
+    - `velocity`: Joint velocity in [rad] / [s].
+    - `torque`: Joint torque in [N m].
+    - `temperature`: Servo temperature in degree Celsius.
+    - `voltage`: Power bus voltage of the servo, in [V].
 
     As with all Upkie environments, full observations from the spine (detailed
-    in \ref observations) are also available in the ``info`` dictionary
+    in \ref observations) are also available in the `info` dictionary
     returned by the reset and step functions.
     """
 
@@ -131,7 +131,7 @@ class UpkieServos(UpkieBaseEnv):
         \param regulate_frequency Enables loop frequency regulation.
         \param shm_name Name of shared-memory file.
         \param spine_config Additional spine configuration overriding the
-            defaults from ``//config:spine.yaml``. The combined configuration
+            defaults from `//config:spine.yaml`. The combined configuration
             dictionary is sent to the spine at every :func:`reset`.
         """
         super().__init__(

--- a/upkie/envs/wheeled_inverted_pendulum.py
+++ b/upkie/envs/wheeled_inverted_pendulum.py
@@ -46,7 +46,7 @@ class WheeledInvertedPendulum(gymnasium.Env):
             <td><strong>Description</strong></td>
             </tr>
         <tr>
-            <td>``0``</td>
+            <td>0</td>
             <td>Ground velocity in [m] / [s].</td>
         </tr>
     </table>
@@ -337,9 +337,9 @@ class WheeledInvertedPendulum(gymnasium.Env):
             number generator.
         \param options Currently unused.
         \return
-            - ``observation``: Initial vectorized observation, i.e. an element
-              of the environment's ``observation_space``.
-            - ``info``: Dictionary with auxiliary diagnostic information. For
+            - `observation`: Initial vectorized observation, i.e. an element
+              of the environment's `observation_space`.
+            - `info`: Dictionary with auxiliary diagnostic information. For
               Upkie this is the full observation dictionary sent by the spine.
         """
         super().reset(seed=seed)
@@ -392,17 +392,17 @@ class WheeledInvertedPendulum(gymnasium.Env):
 
         \param action Action from the agent.
         \return
-            - ``observation``: Observation of the environment, i.e. an element
-              of its ``observation_space``.
-            - ``reward``: Reward returned after taking the action.
-            - ``terminated``: Whether the agent reached a terminal state,
+            - `observation`: Observation of the environment, i.e. an element
+              of its `observation_space`.
+            - `reward`: Reward returned after taking the action.
+            - `terminated`: Whether the agent reached a terminal state,
               which can be a good or a bad thing. When true, the user needs to
               call :func:`reset()`.
-            - ``truncated'': Whether the episode is reaching max number of
+            - `truncated`: Whether the episode is reaching max number of
               steps. This boolean can signal a premature end of the episode,
               i.e. before a terminal state is reached. When true, the user
               needs to call :func:`reset()`.
-            - ``info``: Dictionary with auxiliary diagnostic information. For
+            - `info`: Dictionary with auxiliary diagnostic information. For
               us this is the full observation dictionary coming from the spine.
         """
         if self.__rate is not None:

--- a/upkie/envs/wheeled_inverted_pendulum.py
+++ b/upkie/envs/wheeled_inverted_pendulum.py
@@ -279,14 +279,6 @@ class WheeledInvertedPendulum(gymnasium.Env):
                 "pitch": 0.0,
                 "angular_velocity": np.zeros(3),
             },
-            "groundtruth": {
-                "base": {
-                    "position": np.array([0.0, 0.0, length]),
-                    "orientation": np.array([1.0, 0.0, 0.0, 0.0]),
-                    "linear_velocity": np.zeros(3),
-                    "angular_velocity": np.zeros(3),
-                }
-            },
             "imu": {
                 "raw_angular_velocity": np.zeros(3),
                 "raw_linear_acceleration": np.zeros(3),
@@ -297,6 +289,14 @@ class WheeledInvertedPendulum(gymnasium.Env):
                     "velocity": 0.0,
                 }
                 for joint in model.upper_leg_joints
+            },
+            "sim": {
+                "base": {
+                    "position": np.array([0.0, 0.0, length]),
+                    "orientation": np.array([1.0, 0.0, 0.0, 0.0]),
+                    "linear_velocity": np.zeros(3),
+                    "angular_velocity": np.zeros(3),
+                }
             },
             "wheel_odometry": {
                 "position": 0.0,
@@ -508,8 +508,8 @@ class WheeledInvertedPendulum(gymnasium.Env):
         v = np.array([rd, 0.0]) + self.length * thetad * e_orth
 
         obs = self.__spine_observation  # reference, not a copy
-        obs["groundtruth"]["base"]["position"] = linear_to_3d @ p
-        obs["groundtruth"]["base"]["linear_velocity"] = linear_to_3d @ v
+        obs["sim"]["base"]["position"] = linear_to_3d @ p
+        obs["sim"]["base"]["linear_velocity"] = linear_to_3d @ v
         obs["base_orientation"]["angular_velocity"][1] = thetad
         obs["base_orientation"]["pitch"] = theta
         obs["imu"]["raw_angular_velocity"] = omega_in_imu

--- a/upkie/model/joint.py
+++ b/upkie/model/joint.py
@@ -46,7 +46,7 @@ class Joint:
         """!
         Manual constructor for joint properties.
 
-        (We don't use a ``dataclass`` because Doxygen does not detect
+        (We don't use a `dataclass` because Doxygen does not detect
         attribute-only declarations in Python as of version 1.9.1.)
         """
         self.index = index

--- a/upkie/model/joint_limit.py
+++ b/upkie/model/joint_limit.py
@@ -38,7 +38,7 @@ class JointLimit:
         """!
         Manual constructor for joint limits.
 
-        (We don't use a ``dataclass`` because Doxygen does not detect
+        (We don't use a `dataclass` because Doxygen does not detect
         attribute-only declarations in Python as of version 1.9.1.)
         """
         self.lower = lower

--- a/upkie/utils/rotations.py
+++ b/upkie/utils/rotations.py
@@ -19,7 +19,7 @@ def rotation_matrix_from_quaternion(
     r"""!
     Convert a unit quaternion to the matrix representing the same rotation.
 
-    \param quat Unit quaternion to convert, in ``[w, x, y, z]`` format.
+    \param quat Unit quaternion to convert, in `[w, x, y, z]` format.
     \return Rotation matrix corresponding to this quaternion.
 
     See `Conversion between quaternions and rotation matrices`_.


### PR DESCRIPTION
### Added

- BulletInterface: Report velocity of the base link in groundtruth

### Changed

- actuation: Log simulation groundtruth to `sim`
- BulletInterface: Move simulation body poses to `sim.bodies`