### PR TITLE
CICD: Run nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+    schedule:
+        - cron: "0 0 * * *"
     push:
         branches: [ main ]
     pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: Documentation
 
 on:
+    schedule:
+        - cron: "0 0 * * *"
     push:
         branches: [ main ]
     pull_request:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,6 +1,8 @@
 name: Packaging
 
 on:
+    schedule:
+        - cron: "0 0 * * *"
     push:
         branches: [ main ]
     pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - examples: Simulation with joint friction
 - examples: Simulation with sensor noise
 - spines: Add variant argument to BulletSpine
+- CI: add nightly builds
 
 ### Changed
 


### PR DESCRIPTION
Existing PRs seem to fail due to external factors: https://github.com/upkie/upkie/issues/438 .

This PR adds a nightly build schedule for the main branch (default behaviour of `schedule:`), run at midnight everyday.

Hopefully, we will catch failing builds faster this way, also with less ambiguity (i.e. we'd know it's not the PR itself causing the failure).