### PR TITLE
Update inter-process communication protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- BulletInterface: Fix typo in a comment
 - CICD: Install Doxygen with specific version from conda-forge
+- Spine: Fix observation consistency between `run` and `simulate`
 - envs: Clamp ground velocity action in `UpkieGroundVelocity`
-- BulletInterface: typo fix
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tools: Make output directory an argument in `dump_servo_configs`
 - tools: Simplify servo configuration script
 - **Breaking:** Spine and spine interface revisions:
-    - Internal: Rename spine FSM state from "act" to "step"
-    - Internal: Starting the spine returns an observation
-    - Remove separate observation state and observation request
-    - Specification: Observation is now returned upon resets
-    - Specification: Observation is now returned upon steps
+    - Observations are now returned upon reset and step
+    - Spine: Remove separate observation state and observation request
+    - SpineInterface: Setting an action now returns an observation
+    - SpineInterface: Starting the spine now returns an observation
+    - StateMachine: Rename spine FSM state from "act" to "step"
     - docs: Update spine FSM specification in the documentation
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move Python spine exceptions to `upkie.exceptions`
 - tools: Make output directory an argument in `dump_servo_configs`
 - tools: Simplify servo configuration script
+- **Breaking:** Spine and spine interface revisions:
+    - Internal: Rename spine FSM state from "act" to "step"
+    - Internal: Starting the spine returns an observation
+    - Remove separate observation state and observation request
+    - Specification: Observation is now returned upon resets
+    - Specification: Observation is now returned upon steps
+    - docs: Update spine FSM specification in the documentation
+
 
 ### Fixed
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -71,19 +71,22 @@ Spines run a state machine depicted in the following diagram:
 States have the following purposes:
 
 - **Stop:** do nothing, send stop commands to servos.
-- **Reset:** apply runtime configuration to actuation interface and observers. The reset state is not time-critical, *i.e.*, configuration can take time.
+- **Reset:** apply runtime configuration to the spine's actuation interface and observers.
+    - The reset state is not time-critical, *i.e.*, configuration can take time.
+    - When exiting the reset state, the spine writes observations back to the agent.
 - **Idle:** do nothing.
-- **Observe:** write observation from the actuation interface.
-- **Act:** send action to the actuation interface.
+- **Act:** send action to the actuation interface and write observation back to the agent.
 - **Shutdown:** terminal state, exit the control loop.
 
 There are three possible events:
 
-- `begin`: beginning of a control cycle.
-- `end`: end of a control cycle.
+- `BEGIN`: beginning of a control cycle.
+- `END`: end of a control cycle.
 - `SIGINT`: the process received an interrupt signal.
 
-Guards, indicated between brackets, may involve two variables:
+Guards (in blue), *i.e.* conditions required to trigger a transition, may involve two variables:
 
 - `req`: the current [Request](\ref upkie::cpp::spine::Request) from the agent.
 - `stop_cycles`: the number of stop commands cycled in the current state (only available in "stop" and "shutdown" states).
+
+Read/write operations from/to the shared memory are indicated in red.

--- a/docs/figures/state-machine.dot
+++ b/docs/figures/state-machine.dot
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 Stéphane Caron
+// Copyright 2024 Inria
 
 digraph spine_state_machine {
     bgcolor="transparent"
@@ -11,23 +12,19 @@ digraph spine_state_machine {
     kSendStops[label="Stop"];
     kReset[label="Reset"];
     kIdle[label="Idle"];
-    kObserve[label="Observe"];
     kAct[label="Act"];
     kShutdown[label="Shutdown"];
 
-    initial->kSendStops[label="Initialization"];
-    kSendStops->kReset[label="begin [req=start, stop_cycles>=5]"];
-    kSendStops->kSendStops[label="begin [req!=reset]"];
-    kSendStops->kSendStops[label="end"];
+    initial->kSendStops[label="BEGIN"];
+    kSendStops->kReset[label=<BEGIN <font color="blue">[req=start, stop_cycles≥5]</font><br/><font color="red">read(config)</font>>];
+    kSendStops->kSendStops[label=<BEGIN <font color="blue">[req!=reset]</font>>];
+    kSendStops->kSendStops[label="END"];
     kSendStops->kShutdown[label="SIGINT", style=dashed];
-    kReset->kIdle[label="end"];
-    kIdle->kObserve[label="begin [req=obs]"];
-    kIdle->kAct[label="begin [req=act]"];
-    kIdle->kSendStops[label="begin [req=stop]"];
+    kReset->kIdle[label=<END <br/><font color="red">write(obs)</font>>];
+    kIdle->kAct[label=<BEGIN <font color="blue">[req=act]</font><br/><font color="red">read(action)</font>>];
+    kIdle->kSendStops[label="BEGIN [req=stop]"];
     kIdle->kShutdown[label="SIGINT", style=dashed];
-    kObserve->kIdle[label="end"];
-    kObserve->kShutdown[label="SIGINT", style=dashed];
-    kAct->kIdle[label="end"];
+    kAct->kIdle[label=<END <br/><font color="red">write(obs)</font>>];
     kAct->kShutdown[label="SIGINT", style=dashed];
-    kShutdown->terminal[label="stop_cycles>=5"];
+    kShutdown->terminal[label=<END <font color="blue">[stop_cycles≥5]</font>>];
 }

--- a/docs/figures/state-machine.dot
+++ b/docs/figures/state-machine.dot
@@ -9,11 +9,11 @@ digraph spine_state_machine {
     node [shape=point, label=""] initial, terminal;
     node [shape=square];
 
-    kSendStops[label="Stop"];
-    kReset[label="Reset"];
-    kIdle[label="Idle"];
-    kAct[label="Act"];
-    kShutdown[label="Shutdown"];
+    kSendStops[label="stop"];
+    kReset[label="reset"];
+    kIdle[label="idle"];
+    kStep[label="step"];
+    kShutdown[label="shutdown"];
 
     initial->kSendStops[label="BEGIN"];
     kSendStops->kReset[label=<BEGIN <font color="blue">[req=start, stop_cycles≥5]</font><br/><font color="red">read(config)</font>>];
@@ -21,10 +21,10 @@ digraph spine_state_machine {
     kSendStops->kSendStops[label="END"];
     kSendStops->kShutdown[label="SIGINT", style=dashed];
     kReset->kIdle[label=<END <br/><font color="red">write(obs)</font>>];
-    kIdle->kAct[label=<BEGIN <font color="blue">[req=act]</font><br/><font color="red">read(action)</font>>];
+    kIdle->kStep[label=<BEGIN <font color="blue">[req=act]</font><br/><font color="red">read(action)</font>>];
     kIdle->kSendStops[label="BEGIN [req=stop]"];
     kIdle->kShutdown[label="SIGINT", style=dashed];
-    kAct->kIdle[label=<END <br/><font color="red">write(obs)</font>>];
-    kAct->kShutdown[label="SIGINT", style=dashed];
+    kStep->kIdle[label=<END <br/><font color="red">write(obs)</font>>];
+    kStep->kShutdown[label="SIGINT", style=dashed];
     kShutdown->terminal[label=<END <font color="blue">[stop_cycles≥5]</font>>];
 }

--- a/upkie/cpp/spine/Request.h
+++ b/upkie/cpp/spine/Request.h
@@ -13,20 +13,17 @@ enum class Request : uint32_t {
   //! Flag set when there is no active request.
   kNone = 0,
 
-  //! Flag set to indicate an observation is requested.
-  kObservation = 1,
-
   //! Flag set to indicate an action has been supplied.
-  kAction = 2,
+  kAction = 1,
 
   //! Flag set to start the spine.
-  kStart = 3,
+  kStart = 2,
 
   //! Flag set to stop the spine.
-  kStop = 4,
+  kStop = 3,
 
   //! Flag set when the last request was invalid.
-  kError = 5
+  kError = 4
 };
 
 }  // namespace upkie::cpp::spine

--- a/upkie/cpp/spine/Spine.cpp
+++ b/upkie/cpp/spine/Spine.cpp
@@ -119,7 +119,7 @@ void Spine::simulate(unsigned nb_substeps) {
       cycle_actuation();  // S2: fill servo_replies_ from actuation_output_
       cycle_actuation();  // S3: fill observation dict from servo_replies_
       // now the first observation is ready to be read by the agent
-    } else if (state_machine_.state() == State::kAct) {
+    } else if (state_machine_.state() == State::kStep) {
       for (unsigned substep = 0; substep < nb_substeps; ++substep) {
         cycle_actuation();
       }
@@ -145,7 +145,7 @@ void Spine::begin_cycle() {
       config.clear();
       config.update(data, size);
       reset(config);
-    } else if (state_machine_.state() == State::kAct) {
+    } else if (state_machine_.state() == State::kStep) {
       Dictionary& action = working_dict_("action");
       const char* data = agent_interface_.data();
       size_t size = agent_interface_.size();
@@ -162,7 +162,7 @@ void Spine::end_cycle() {
   const Dictionary& observation = working_dict_("observation");
   working_dict_("time") = observation.get<double>("time");
   if (state_machine_.state() == State::kReset ||
-      state_machine_.state() == State::kAct) {
+      state_machine_.state() == State::kStep) {
     size_t size = observation.serialize(ipc_buffer_);
     agent_interface_.write(ipc_buffer_.data(), size);
   }
@@ -194,7 +194,7 @@ void Spine::cycle_actuation() {
     if (state_machine_.state() == State::kSendStops ||
         state_machine_.state() == State::kShutdown) {
       actuation_.write_stop_commands();
-    } else if (state_machine_.state() == State::kAct) {
+    } else if (state_machine_.state() == State::kStep) {
       const Dictionary& action = working_dict_("action");
       actuation_.process_action(action);
       actuation_.write_position_commands(action);

--- a/upkie/cpp/spine/Spine.cpp
+++ b/upkie/cpp/spine/Spine.cpp
@@ -161,7 +161,8 @@ void Spine::end_cycle() {
   // Write observation if applicable
   const Dictionary& observation = working_dict_("observation");
   working_dict_("time") = observation.get<double>("time");
-  if (state_machine_.state() == State::kObserve) {
+  if (state_machine_.state() == State::kReset ||
+      state_machine_.state() == State::kAct) {
     size_t size = observation.serialize(ipc_buffer_);
     agent_interface_.write(ipc_buffer_.data(), size);
   }

--- a/upkie/cpp/spine/Spine.cpp
+++ b/upkie/cpp/spine/Spine.cpp
@@ -118,13 +118,17 @@ void Spine::simulate(unsigned nb_substeps) {
       cycle_actuation();  // S1: cycle the simulator, promise actuation_output_
       cycle_actuation();  // S2: fill servo_replies_ from actuation_output_
       cycle_actuation();  // S3: fill observation dict from servo_replies_
+      end_cycle();
       // now the first observation is ready to be read by the agent
     } else if (state_machine_.state() == State::kStep) {
-      for (unsigned substep = 0; substep < nb_substeps; ++substep) {
+      cycle_actuation();
+      end_cycle();  // important: writes observation of the first substep
+      for (unsigned substep = 1; substep < nb_substeps; ++substep) {
         cycle_actuation();
       }
+    } else {
+      end_cycle();
     }
-    end_cycle();
   }
 }
 

--- a/upkie/cpp/spine/StateMachine.cpp
+++ b/upkie/cpp/spine/StateMachine.cpp
@@ -42,7 +42,7 @@ void StateMachine::process_cycle_beginning() {
         case Request::kNone:
           break;
         case Request::kAction:
-          enter_state(State::kAct);
+          enter_state(State::kStep);
           break;
         case Request::kStart:
           spdlog::warn(
@@ -63,8 +63,9 @@ void StateMachine::process_cycle_beginning() {
       spdlog::warn(
           "Event::kCycleBeginning should not happen from State::kReset");
       break;
-    case State::kAct:
-      spdlog::warn("Event::kCycleBeginning should not happen from State::kAct");
+    case State::kStep:
+      spdlog::warn(
+          "Event::kCycleBeginning should not happen from State::kStep");
       break;
     case State::kSendStops:
       switch (request) {
@@ -109,7 +110,7 @@ void StateMachine::process_cycle_end() {
         spdlog::info("Stop cycle {} / {}", stop_cycles_, kNbStopCycles);
       }
       break;
-    case State::kAct:
+    case State::kStep:
       enter_state(State::kIdle);
       break;
     case State::kShutdown:
@@ -133,7 +134,7 @@ void StateMachine::enter_state(const State& next_state) noexcept {
       interface_.set_request(Request::kNone);
       break;
     case State::kReset:
-    case State::kAct:
+    case State::kStep:
       break;
     case State::kSendStops:
     case State::kShutdown:

--- a/upkie/cpp/spine/StateMachine.cpp
+++ b/upkie/cpp/spine/StateMachine.cpp
@@ -109,9 +109,6 @@ void StateMachine::process_cycle_end() {
         spdlog::info("Stop cycle {} / {}", stop_cycles_, kNbStopCycles);
       }
       break;
-    case State::kObserve:
-      enter_state(State::kIdle);
-      break;
     case State::kAct:
       enter_state(State::kIdle);
       break;
@@ -136,7 +133,6 @@ void StateMachine::enter_state(const State& next_state) noexcept {
       interface_.set_request(Request::kNone);
       break;
     case State::kReset:
-    case State::kObserve:
     case State::kAct:
       break;
     case State::kSendStops:

--- a/upkie/cpp/spine/StateMachine.cpp
+++ b/upkie/cpp/spine/StateMachine.cpp
@@ -41,9 +41,6 @@ void StateMachine::process_cycle_beginning() {
       switch (request) {
         case Request::kNone:
           break;
-        case Request::kObservation:
-          enter_state(State::kObserve);
-          break;
         case Request::kAction:
           enter_state(State::kAct);
           break;
@@ -66,10 +63,6 @@ void StateMachine::process_cycle_beginning() {
       spdlog::warn(
           "Event::kCycleBeginning should not happen from State::kReset");
       break;
-    case State::kObserve:
-      spdlog::warn(
-          "Event::kCycleBeginning should not happen from State::kObserve");
-      break;
     case State::kAct:
       spdlog::warn("Event::kCycleBeginning should not happen from State::kAct");
       break;
@@ -77,7 +70,6 @@ void StateMachine::process_cycle_beginning() {
       switch (request) {
         case Request::kNone:
           break;
-        case Request::kObservation:
         case Request::kAction:
           interface_.set_request(Request::kError);
           break;

--- a/upkie/cpp/spine/StateMachine.h
+++ b/upkie/cpp/spine/StateMachine.h
@@ -21,17 +21,14 @@ enum class State : uint32_t {
   //! Do nothing
   kIdle = 2,
 
-  //! Write an observation to shared memory
-  kObserve = 3,
-
   //! Read a new action from shared memory
-  kAct = 4,
+  kAct = 3,
 
   //! Shut down the spine
-  kShutdown = 5,
+  kShutdown = 4,
 
   //! Final termination
-  kOver = 6
+  kOver = 5
 };
 
 //! Events that may trigger transitions between states.
@@ -58,8 +55,6 @@ constexpr const char* state_name(const State& state) noexcept {
       return "State::kReset";
     case State::kIdle:
       return "State::kIdle";
-    case State::kObserve:
-      return "State::kObserve";
     case State::kAct:
       return "State::kAct";
     case State::kShutdown:

--- a/upkie/cpp/spine/StateMachine.h
+++ b/upkie/cpp/spine/StateMachine.h
@@ -22,7 +22,7 @@ enum class State : uint32_t {
   kIdle = 2,
 
   //! Read a new action from shared memory
-  kAct = 3,
+  kStep = 3,
 
   //! Shut down the spine
   kShutdown = 4,
@@ -55,8 +55,8 @@ constexpr const char* state_name(const State& state) noexcept {
       return "State::kReset";
     case State::kIdle:
       return "State::kIdle";
-    case State::kAct:
-      return "State::kAct";
+    case State::kStep:
+      return "State::kStep";
     case State::kShutdown:
       return "State::kShutdown";
     case State::kOver:

--- a/upkie/cpp/spine/tests/AgentInterfaceTest.cpp
+++ b/upkie/cpp/spine/tests/AgentInterfaceTest.cpp
@@ -30,8 +30,8 @@ class AgentInterfaceTest : public ::testing::Test {
 };
 
 TEST_F(AgentInterfaceTest, GetSetRequest) {
-  agent_interface_->set_request(Request::kObservation);
-  ASSERT_EQ(agent_interface_->request(), Request::kObservation);
+  agent_interface_->set_request(Request::kReset);
+  ASSERT_EQ(agent_interface_->request(), Request::kReset);
   agent_interface_->set_request(Request::kAction);
   ASSERT_EQ(agent_interface_->request(), Request::kAction);
 }

--- a/upkie/cpp/spine/tests/AgentInterfaceTest.cpp
+++ b/upkie/cpp/spine/tests/AgentInterfaceTest.cpp
@@ -30,8 +30,8 @@ class AgentInterfaceTest : public ::testing::Test {
 };
 
 TEST_F(AgentInterfaceTest, GetSetRequest) {
-  agent_interface_->set_request(Request::kReset);
-  ASSERT_EQ(agent_interface_->request(), Request::kReset);
+  agent_interface_->set_request(Request::kStart);
+  ASSERT_EQ(agent_interface_->request(), Request::kStart);
   agent_interface_->set_request(Request::kAction);
   ASSERT_EQ(agent_interface_->request(), Request::kAction);
 }

--- a/upkie/cpp/spine/tests/SpineTest.cpp
+++ b/upkie/cpp/spine/tests/SpineTest.cpp
@@ -237,7 +237,7 @@ TEST_F(SpineTest, SetObservationOnIdle) {
 
 TEST_F(SpineTest, WriteObservationOnRequest) {
   start_spine();
-  write_mmap_request(Request::kAct);
+  write_mmap_request(Request::kStep);
   spine_->cycle();
   const Dictionary& observation = spine_->working_dict()("observation");
   ASSERT_TRUE(observation.get<bool>("schwifty"));
@@ -246,7 +246,7 @@ TEST_F(SpineTest, WriteObservationOnRequest) {
 TEST_F(SpineTest, ObserverExceptionStopsRun) {
   start_spine();
   schwifty_observer_->throw_exception = true;
-  write_mmap_request(Request::kAct);
+  write_mmap_request(Request::kStep);
   spine_->cycle();
   ASSERT_TRUE(spine_->all_commands_are_stops());
   ASSERT_EQ(spine_->state(), State::kShutdown);

--- a/upkie/cpp/spine/tests/SpineTest.cpp
+++ b/upkie/cpp/spine/tests/SpineTest.cpp
@@ -237,7 +237,7 @@ TEST_F(SpineTest, SetObservationOnIdle) {
 
 TEST_F(SpineTest, WriteObservationOnRequest) {
   start_spine();
-  write_mmap_request(Request::kObservation);
+  write_mmap_request(Request::kAct);
   spine_->cycle();
   const Dictionary& observation = spine_->working_dict()("observation");
   ASSERT_TRUE(observation.get<bool>("schwifty"));
@@ -246,7 +246,7 @@ TEST_F(SpineTest, WriteObservationOnRequest) {
 TEST_F(SpineTest, ObserverExceptionStopsRun) {
   start_spine();
   schwifty_observer_->throw_exception = true;
-  write_mmap_request(Request::kObservation);
+  write_mmap_request(Request::kAct);
   spine_->cycle();
   ASSERT_TRUE(spine_->all_commands_are_stops());
   ASSERT_EQ(spine_->state(), State::kShutdown);

--- a/upkie/cpp/spine/tests/SpineTest.cpp
+++ b/upkie/cpp/spine/tests/SpineTest.cpp
@@ -237,7 +237,7 @@ TEST_F(SpineTest, SetObservationOnIdle) {
 
 TEST_F(SpineTest, WriteObservationOnRequest) {
   start_spine();
-  write_mmap_request(Request::kStep);
+  write_mmap_request(Request::kAction);
   spine_->cycle();
   const Dictionary& observation = spine_->working_dict()("observation");
   ASSERT_TRUE(observation.get<bool>("schwifty"));
@@ -246,7 +246,7 @@ TEST_F(SpineTest, WriteObservationOnRequest) {
 TEST_F(SpineTest, ObserverExceptionStopsRun) {
   start_spine();
   schwifty_observer_->throw_exception = true;
-  write_mmap_request(Request::kStep);
+  write_mmap_request(Request::kAction);
   spine_->cycle();
   ASSERT_TRUE(spine_->all_commands_are_stops());
   ASSERT_EQ(spine_->state(), State::kShutdown);

--- a/upkie/cpp/spine/tests/StateMachineTest.cpp
+++ b/upkie/cpp/spine/tests/StateMachineTest.cpp
@@ -87,10 +87,10 @@ TEST_F(StateMachineTest, Startup) {
   ASSERT_EQ(request(), Request::kNone);
 }
 
-TEST_F(StateMachineTest, ObserveWhenSendingStopsFails) {
+TEST_F(StateMachineTest, SteppingWhenSendingStopsFails) {
   ASSERT_EQ(state(), State::kSendStops);
 
-  set_request(Request::kObservation);
+  set_request(Request::kAct);
   state_machine_->process_event(Event::kCycleBeginning);
   ASSERT_EQ(state(), State::kSendStops);
   ASSERT_EQ(request(), Request::kError);

--- a/upkie/cpp/spine/tests/StateMachineTest.cpp
+++ b/upkie/cpp/spine/tests/StateMachineTest.cpp
@@ -87,10 +87,10 @@ TEST_F(StateMachineTest, Startup) {
   ASSERT_EQ(request(), Request::kNone);
 }
 
-TEST_F(StateMachineTest, SteppingWhenSendingStopsFails) {
+TEST_F(StateMachineTest, ActingWhenSendingStopsFails) {
   ASSERT_EQ(state(), State::kSendStops);
 
-  set_request(Request::kStep);
+  set_request(Request::kAction);
   state_machine_->process_event(Event::kCycleBeginning);
   ASSERT_EQ(state(), State::kSendStops);
   ASSERT_EQ(request(), Request::kError);

--- a/upkie/cpp/spine/tests/StateMachineTest.cpp
+++ b/upkie/cpp/spine/tests/StateMachineTest.cpp
@@ -90,7 +90,7 @@ TEST_F(StateMachineTest, Startup) {
 TEST_F(StateMachineTest, SteppingWhenSendingStopsFails) {
   ASSERT_EQ(state(), State::kSendStops);
 
-  set_request(Request::kAct);
+  set_request(Request::kStep);
   state_machine_->process_event(Event::kCycleBeginning);
   ASSERT_EQ(state(), State::kSendStops);
   ASSERT_EQ(request(), Request::kError);

--- a/upkie/envs/tests/mock_spine.py
+++ b/upkie/envs/tests/mock_spine.py
@@ -44,7 +44,5 @@ class MockSpine:
 
     def set_action(self, action) -> None:
         self.action = action
-
-    def get_observation(self) -> dict:
         self.observation["number"] += 1
         return self.observation

--- a/upkie/envs/tests/mock_spine.py
+++ b/upkie/envs/tests/mock_spine.py
@@ -36,13 +36,16 @@ class MockSpine:
             },
         }
 
-    def start(self, config: dict) -> None:
-        pass
+    def _next_observation(self) -> dict:
+        self.observation["number"] += 1
+        return self.observation
+
+    def start(self, config: dict) -> dict:
+        return self._next_observation()
 
     def stop(self) -> None:
         pass
 
-    def set_action(self, action) -> None:
+    def set_action(self, action) -> dict:
         self.action = action
-        self.observation["number"] += 1
-        return self.observation
+        return self._next_observation()

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -230,7 +230,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             self.__rate.sleep()  # wait until clock tick to send the action
             self.log("rate", {"slack": self.__rate.slack})
 
-        # Act
+        # Prepare spine action
         spine_action = self.get_spine_action(action)
         for key in ("bullet", "log"):
             if not self.__extras[key]:
@@ -238,10 +238,11 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             spine_action[key] = {}
             spine_action[key].update(self.__extras[key])
             self.__extras[key].clear()
-        self._spine.set_action(spine_action)
 
-        # Observe
-        spine_observation = self._spine.get_observation()
+        # Send action to and get observation from the spine
+        spine_observation = self._spine.set_action(spine_action)
+
+        # Process spine observation
         observation = self.get_env_observation(spine_observation)
         reward = self.get_reward(observation, action)
         terminated = self.detect_fall(spine_observation)

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -169,9 +169,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
         self._spine.stop()
         self.__reset_rate()
         self.__reset_init_state()
-        self._spine.start(self._spine_config)
-        self._spine.get_observation()  # might be a pre-reset observation
-        spine_observation = self._spine.get_observation()
+        spine_observation = self._spine.start(self._spine_config)
         self.parse_first_observation(spine_observation)
         observation = self.get_env_observation(spine_observation)
         info = {"spine_observation": spine_observation}

--- a/upkie/spine/request.py
+++ b/upkie/spine/request.py
@@ -21,9 +21,6 @@ class Request(IntEnum):
     @var kNone
     Flag set when there is no active request.
 
-    @var kObservation
-    Flag set to indicate an observation is requested.
-
     @var kAction
     Flag set to indicate an action has been supplied.
 
@@ -38,8 +35,7 @@ class Request(IntEnum):
     """
 
     kNone = 0
-    kObservation = 1
-    kAction = 2
-    kStart = 3
-    kStop = 4
-    kError = 5
+    kAction = 1
+    kStart = 2
+    kStop = 3
+    kError = 4

--- a/upkie/spine/spine_interface.py
+++ b/upkie/spine/spine_interface.py
@@ -67,15 +67,6 @@ class SpineInterface:
         if hasattr(self, "_shared_memory"):  # handle ctor exceptions
             self._shared_memory.close()
 
-    def get_first_observation(self) -> dict:
-        r"""!
-        Get first observation after a reset.
-
-        \return Observation dictionary.
-        """
-        self.get_observation()  # pre-reset observation, skipped
-        return self.get_observation()
-
     def set_action(self, action: dict) -> dict:
         r"""!
         Set action for the spine to process.

--- a/upkie/spine/spine_interface.py
+++ b/upkie/spine/spine_interface.py
@@ -67,22 +67,6 @@ class SpineInterface:
         if hasattr(self, "_shared_memory"):  # handle ctor exceptions
             self._shared_memory.close()
 
-    def get_observation(self) -> dict:
-        r"""!
-        Ask the spine to write the latest observation to shared memory.
-
-        \return Observation dictionary.
-
-        \note In simulation, the first observation after a reset was collected
-        before that reset. Use \ref get_first_observation in that case to skip
-        to the first post-reset observation.
-        """
-        self._wait_for_spine()
-        self._write_request(Request.kObservation)
-        self._wait_for_spine()
-        observation = self._read_dict()
-        return observation
-
     def get_first_observation(self) -> dict:
         r"""!
         Get first observation after a reset.
@@ -92,15 +76,19 @@ class SpineInterface:
         self.get_observation()  # pre-reset observation, skipped
         return self.get_observation()
 
-    def set_action(self, action: dict) -> None:
+    def set_action(self, action: dict) -> dict:
         r"""!
         Set action for the spine to process.
 
         \param[in] action Action dictionary.
+        \return Observation dictionary.
         """
         self._wait_for_spine()
         self._write_dict(action)
         self._write_request(Request.kAction)
+        self._wait_for_spine()
+        observation = self._read_dict()
+        return observation
 
     def start(self, config: dict) -> None:
         r"""!

--- a/upkie/spine/spine_interface.py
+++ b/upkie/spine/spine_interface.py
@@ -86,10 +86,14 @@ class SpineInterface:
         Reset the spine to a new configuration.
 
         \param[in] config Configuration dictionary.
+        \return Observation dictionary.
         """
         self._wait_for_spine()
         self._write_dict(config)
         self._write_request(Request.kStart)
+        self._wait_for_spine()
+        observation = self._read_dict()
+        return observation
 
     def stop(self) -> None:
         """!

--- a/upkie/spine/tests/spine_interface_test.py
+++ b/upkie/spine/tests/spine_interface_test.py
@@ -57,10 +57,9 @@ class TestSpineInterface(unittest.TestCase):
             Args:
                 spine: The spine interface waiting for a free request slot.
             """
-            if self.__read_request() == Request.kObservation:
-                self.__write_observation(self.next_observation)
-            elif self.__read_request() == Request.kAction:
+            if self.__read_request() == Request.kAction:
                 self.last_action = self.__read_dict()
+                self.__write_observation(self.next_observation)
             elif self.__read_request() == Request.kStart:
                 self.last_config = self.__read_dict()
             self.assertEqual(self.__read_request(), Request.kNone)


### PR DESCRIPTION
Changes:

- Observations are now returned upon reset and step
- Spine: Remove separate observation state and observation request
- SpineInterface: Setting an action now returns an observation
- SpineInterface: Starting the spine now returns an observation
- StateMachine: Rename spine FSM state from "act" to "step"
- docs: Update spine FSM specification in the documentation

New state machine:

![image](https://github.com/user-attachments/assets/2d696234-a13e-4189-8f9b-4046333c4c5b)

Level of confidence:

- Unit tests: :heavy_check_mark: 
- Tested in sim: Bullet spine :heavy_check_mark: 
- Tested on an Upkie: Rookie :heavy_check_mark: 