### PR TITLE
Index Gymnasium environments in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CICD: Pin Ubuntu workflows to 22.04
 - Default `kd` gain for wheel servos is now 0.3
 - Move Python spine exceptions to `upkie.exceptions`
+- docs: Turn environment page into an index
 - tools: Make output directory an argument in `dump_servo_configs`
 - tools: Simplify servo configuration script
 - **Breaking:** Spine and spine interface revisions:
@@ -27,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - SpineInterface: Starting the spine now returns an observation
     - StateMachine: Rename spine FSM state from "act" to "step"
     - docs: Update spine FSM specification in the documentation
-
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install upkie
 Upkie implements an action-observation loop to control robots from a standalone "agent" process, like this:
 
 <p align="center">
-    <img alt="Action-observation loop" src="https://github.com/upkie/upkie/blob/main/docs/figures/action-observation-loop.svg" />
+    <img alt="Action-observation loop" src="https://raw.githubusercontent.com/upkie/upkie/refs/heads/main/docs/figures/action-observation-loop.svg" />
 </p>
 
 The agent can be a simple Python script with few dependencies. This separation between agent and spine provides a robot/simulation switch to train or test agents in a simulation spine before running them on a real robot.

--- a/README.md
+++ b/README.md
@@ -42,14 +42,6 @@ pip install upkie
 
 ## Getting started
 
-Upkie implements an action-observation loop to control robots from a standalone "agent" process, like this:
-
-<p align="center">
-    <img alt="Action-observation loop" src="https://raw.githubusercontent.com/upkie/upkie/refs/heads/main/docs/figures/action-observation-loop.svg" />
-</p>
-
-The agent can be a simple Python script with few dependencies. This separation between agent and spine provides a robot/simulation switch to train or test agents in a simulation spine before running them on a real robot.
-
 Let's start a Bullet simulation spine:
 
 <img src="https://github.com/upkie/upkie/blob/main/docs/images/bullet-spine.png" height="100" align="right" />

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Let's start a Bullet simulation spine:
 ./start_simulation.sh
 ```
 
-Click on the robot in the simulator window to apply external forces. Once the simulation spine is running, we can interact with it using one of the [Gymnasium environments](https://upkie.github.io/upkie/environments.html). For example, here is a linear-feedback balancer for ``UpkieGroundVelocity``:
+Click on the robot in the simulator window to apply external forces. Once the simulation spine is running, we can control the robot using one of its Gymnasium environments, for instance:
 
 ```python
 import gymnasium as gym
@@ -69,18 +69,18 @@ with gym.make("UpkieGroundVelocity-v3", frequency=200.0) as env:
             observation, _ = env.reset()
 ```
 
-The Python code is the same whether running a simulation or real-robot [spine](https://upkie.github.io/upkie/spines.html).
+The Python code stays the same whether we run a simulation or on a real Upkie. There are also many environments to pick from, check out the list of [Upkie Gymnasium environments](https://upkie.github.io/upkie/environments.html)
 
 ## Agents
 
-This repository distributes standalone Python agents in the [examples](https://github.com/upkie/upkie/tree/main/examples) directory. Larger Upkie agents, some of them with custom C++ spines, are distributed in their own repositories:
+This main repository distributes Gymnasium environments and [examples](https://github.com/upkie/upkie/tree/main/examples). Larger Upkie agents, some of them with custom C++ spines, have their own repositories:
 
 - [MPC balancer](https://github.com/upkie/mpc_balancer): balance in place using model predictive control.
 - [Pink balancer](https://github.com/upkie/pink_balancer): a more advanced agent that can crouch and stand up while balancing.
 - [PPO balancer](https://github.com/upkie/ppo_balancer): balance in place with a policy trained by reinforcement learning.
 - [PID balancer](https://github.com/upkie/pid_balancer): legacy agent used to test new Upkies with minimal dependencies.
 
-Head over to the [new\_agent](https://github.com/upkie/new_agent) template to create your own, and feel free to open a PR here to add your agent to the list above.
+Head over to the [new\_agent](https://github.com/upkie/new_agent) template to create your own, and feel free to open a PR here to add your agent to the list.
 
 ## How can I participate?
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -46,7 +46,15 @@ ln -s ../upkie ./
 
 ## Inter-process communication
 
-Upkie's software implements an inter-process communication (IPC) protocol between spines and agents. This protocol is suitable for [real-time](https://en.wiktionary.org/wiki/real-time#English) but not high-frequency (> 1000 Hz) performance, which is fine for balancing and locomotion on Upkies. (If you are wondering whether Python is suitable for real-time applications, we were too, until we [tried it out](https://github.com/orgs/upkie/discussions/240).) All design decisions have their pros and cons. Some pros for this design are:
+Upkie implements an action-observation loop to control robot actuators from a standalone "agent" process. The inter-process communication (IPC) protocol between the agent and the "spine" process that talks to actuators looks like this:
+
+<p align="center">
+    <img alt="Action-observation loop" src="action-observation-loop.png" />
+</p>
+
+The agent can be a simple Python script with few dependencies. This separation between agent and spine provides a robot/simulation switch to train or test agents in a simulation spine before running them on a real robot.
+
+This protocol is suitable for [real-time](https://en.wiktionary.org/wiki/real-time#English) but not high-frequency (> 1000 Hz) performance, which is fine for balancing and locomotion on Upkies. (If you are wondering whether Python is suitable for real-time applications, we were too, until we [tried it out](https://github.com/orgs/upkie/discussions/240).) All design decisions have their pros and cons. Some pros for this design are:
 
 - Run the same Python code on simulated and real robots
 - Interfaces with to the [mjbots pi3hat](https://mjbots.com/products/mjbots-pi3hat-r4-4b) and mjbots actuators

--- a/docs/gym-environments.md
+++ b/docs/gym-environments.md
@@ -8,29 +8,6 @@ Upkie has reinforcement learning environments following the [Gymnasium](https://
 
 Each environment has its own observation and action spaces, but all of them provide access to full spine observation via `info` dictionaries. See \ref observations for details.
 
-## Ground velocity {#ground-velocity-env}
-
-In the `UpkieGroundVelocity` environment, Upkie keeps its legs straight and actions only affect wheel velocities. This environment is used for instance by the [MPC balancer](https://github.com/upkie/mpc_balancer/) and [PPO balancer](https://github.com/upkie/ppo_balancer) agents.
-
-**Observation:** The observation \f$o\f$ consists of:
-
-\f[
-\begin{align*}
-o &= \begin{bmatrix} \theta \\ p \\ \dot{\theta} \\ \dot{p} \end{bmatrix}
-\end{align*}
-\f]
-
-where we denote by:
-
-- \f$\theta\f$ the pitch angle of the base with respect to the world vertical, in radians.
-- \f$p\f$ the position of the average wheel contact point, in meters.
-
-**Action:** The action \f$a =\begin{bmatrix} \dot{p}^* \end{bmatrix}\f$ consists of:
-
-- \f$\dot{p}^*\f$ the commanded ground velocity, which is then internally converted to wheel velocity commands.
-
-You can find more details about the environment in the [UpkieGroundVelocity](\ref upkie.envs.upkie_ground_velocity.UpkieGroundVelocity) class documentation.
-
 ## Servos {#servos-env}
 
 ### Servo positions

--- a/docs/gym-environments.md
+++ b/docs/gym-environments.md
@@ -1,6 +1,12 @@
 # Gym environments {#environments}
 
-Upkie has reinforcement learning environments following the [Gymnasium](https://gymnasium.farama.org/) API. All of them are single-threaded and run as-is in both simulation and on real robots. Each environment has its own observation and action spaces, but all of them provide access to full spine observation via `info` dictionaries. See \ref observations for details.
+Upkie has reinforcement learning environments following the [Gymnasium](https://gymnasium.farama.org/) API. All of them are single-threaded and run as-is in both simulation and on real robots.
+
+- [UpkieBaseEnv](\ref upkie.envs.upkie_base_env.UpkieBaseEnv)
+    - [UpkieGroundVelocity](\ref upkie_ground_velocity_description)
+    - [UpkieServos](\ref upkie_servos_description)
+
+Each environment has its own observation and action spaces, but all of them provide access to full spine observation via `info` dictionaries. See \ref observations for details.
 
 ## Ground velocity {#ground-velocity-env}
 

--- a/docs/gym-environments.md
+++ b/docs/gym-environments.md
@@ -5,20 +5,9 @@ Upkie has reinforcement learning environments following the [Gymnasium](https://
 - [UpkieBaseEnv](\ref upkie.envs.upkie_base_env.UpkieBaseEnv)
     - [UpkieGroundVelocity](\ref upkie_ground_velocity_description)
     - [UpkieServos](\ref upkie_servos_description)
+        - [UpkieServoPositions](\ref upkie_servo_positions_description)
 
 Each environment has its own observation and action spaces, but all of them provide access to full spine observation via `info` dictionaries. See \ref observations for details.
-
-## Servos {#servos-env}
-
-### Servo positions
-
-The [UpkieServoPositions](\ref upkie.envs.upkie_servo_positions.UpkieServoPositions) has the same observation space as UpkieServos, but the action space is only composed of \f$\theta\f$, \f$k_d\f$ and \f$k_p\f$. This makes the agent command servo positions with velocity damping:
-
-\f[
-\begin{align*}
-\tau & = k_{p} k_{p}^{\mathit{scale}} (\theta^* - \theta) - k_{d} k_{d}^{\mathit{scale}} \dot{\theta}
-\end{align*}
-\f]
 
 ### Servo torques
 

--- a/docs/gym-environments.md
+++ b/docs/gym-environments.md
@@ -33,41 +33,6 @@ You can find more details about the environment in the [UpkieGroundVelocity](\re
 
 ## Servos {#servos-env}
 
-The `UpkieServos` environment has dictionary observation and action spaces.
-
-**Observation:** observation dictionaries report, for each servo, the following keys:
-
-- `position`: joint position in [rad].
-- `velocity`: joint velocity in [rad] / [s].
-- `torque`: joint torque in [N m].
-
-**Action:** Action dictionaries specify servo targets:
-
-- `position`: commanded joint angle in [rad].
-- `velocity`: commanded joint velocity in [rad] / [s].
-- `feedforward_torque`: feedforward joint torque in [N m].
-
-Those commands that are directly sent to the moteus controllers, which will in turn apply a standard control law with feedforward torque and position-velocity feedback:
-
-\f[
-\begin{align*}
-\tau & = \tau_{\mathit{ff}} + k_{p} k_{p}^{\mathit{scale}} (\theta^* - \theta) + k_{d} k_{d}^{\mathit{scale}} (\dot{\theta}^* - \dot{\theta})
-\end{align*}
-\f]
-
-where for joint \f$i\f$ we denote by:
-
-- \f$\tau\f$ is the commanded joint torque,
-- \f$\tau_{\mathit{ff}}\f$ the feedforward torque (set only this one for direct torque control),
-- \f$\theta\f$ the measured joint position,
-- \f$\dot{\theta}\f$ the measured joint velocity,
-- \f$\theta^*\f$ the target joint position,
-- \f$\dot{\theta}^*\f$ the target joint velocity.
-
-Position and velocity gains \f$k_{p}\f$ and \f$k_{d}\f$ are configured in each moteus controller directly and don't change during execution. We can rather modulate the overall feedback gains via the normalized parameters \f$k_{p}^{\mathit{scale}} \in [0, 1]\f$ and \f$k_{d}^{\mathit{scale}} \in [0, 1]\f$.
-
-Check out the [UpkieServos](\ref upkie.envs.upkie_servos.UpkieServos) documentation for more details.
-
 ### Servo positions
 
 The [UpkieServoPositions](\ref upkie.envs.upkie_servo_positions.UpkieServoPositions) has the same observation space as UpkieServos, but the action space is only composed of \f$\theta\f$, \f$k_d\f$ and \f$k_p\f$. This makes the agent command servo positions with velocity damping:

--- a/docs/gym-environments.md
+++ b/docs/gym-environments.md
@@ -1,20 +1,11 @@
 # Gym environments {#environments}
 
-Upkie has reinforcement learning environments following the [Gymnasium](https://gymnasium.farama.org/) API. All of them are single-threaded and run as-is in both simulation and on real robots.
+Upkie has reinforcement learning environments following the [Gymnasium API](https://gymnasium.farama.org/).
 
-- [UpkieBaseEnv](\ref upkie.envs.upkie_base_env.UpkieBaseEnv)
-    - [UpkieGroundVelocity](\ref upkie_ground_velocity_description)
-    - [UpkieServos](\ref upkie_servos_description)
-        - [UpkieServoPositions](\ref upkie_servo_positions_description)
+- [UpkieBaseEnv](\ref upkie.envs.upkie_base_env.UpkieBaseEnv): base class for all Upkie environments.
+    - [UpkieGroundVelocity](\ref upkie_ground_velocity_description): behave like a wheeled inverted pendulum.
+    - [UpkieServos](\ref upkie_servos_description): action and observation correspond to the full servo API.
+        - [UpkieServoPositions](\ref upkie_servo_positions_description): joint position control only.
+        - [UpkieServoTorques](\ref upkie_servo_torques_description): joint torque control only.
 
-Each environment has its own observation and action spaces, but all of them provide access to full spine observation via `info` dictionaries. See \ref observations for details.
-
-### Servo torques
-
-The [UpkieServoTorques](\ref upkie.envs.upkie_servo_torques.UpkieServoTorques) has the same observation space as UpkieServos, but the action space is only composed of \f$\tau_{\mathit{ff}}\f$. This makes the agent command joint torques directly:
-
-\f[
-\begin{align*}
-\tau & = \tau_{\mathit{ff}}
-\end{align*}
-\f]
+Upkie environments are single-threaded and run as-is in both simulation and on real robots. While each environment has its own observation and action spaces, all of them also report full [spine observations](\ref observations) in their `info` dictionaries.

--- a/docs/real-robot-spines.md
+++ b/docs/real-robot-spines.md
@@ -2,11 +2,11 @@
 
 There are two real-robot spines: the mock spine, and the pi3hat spine.
 
-## mock spine {#mock-spine}
+## Mock spine {#mock-spine}
 
 The mock spine is useful to run an agent on the robot without firing up the actuators. It works exactly as the pi3hat spine, replacing "pi3hat" with "mock" in all instructions.
 
-## pi3hat spine {#pi3hat-spine}
+## Pi3hat spine {#pi3hat-spine}
 
 The pi3hat spine is the one that runs on the real robot, where a [pi3hat r4.5](https://mjbots.com/products/mjbots-pi3hat-r4-5) is mounted on top of the onboard Raspberry Pi computer. To run this spine, you can either download it from GitHub, or build it locally from source.
 

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -26,8 +26,8 @@ class UpkieGroundVelocity(UpkieBaseEnv):
 
     \anchor upkie_ground_velocity_description
 
-    In the `UpkieGroundVelocity` environment, Upkie keeps its legs straight and
-    actions only affect wheel velocities. This way, it behaves like a <a
+    With this environment, Upkie keeps its legs straight and actions only
+    affect wheel velocities. This way, it behaves like a <a
     href="https://scaron.info/robotics/wheeled-inverted-pendulum-model.html">wheeled
     inverted pendulum</a>. This ground-velocity environment is used for
     instance by the [MPC balancer](https://github.com/upkie/mpc_balancer/) and

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -24,9 +24,14 @@ class UpkieGroundVelocity(UpkieBaseEnv):
     r"""!
     Environment where Upkie is used as a wheeled inverted pendulum.
 
-    Model assumptions of the wheeled inverted pendulum are summarized in the <a
-    href="https://scaron.info/robotics/wheeled-inverted-pendulum-model.html">following
-    note</a>.
+    \anchor upkie_ground_velocity_description
+
+    In the `UpkieGroundVelocity` environment, Upkie keeps its legs straight and
+    actions only affect wheel velocities. This way, it behaves like a <a
+    href="https://scaron.info/robotics/wheeled-inverted-pendulum-model.html">wheeled
+    inverted pendulum</a>. This ground-velocity environment is used for
+    instance by the [MPC balancer](https://github.com/upkie/mpc_balancer/) and
+    [PPO balancer](https://github.com/upkie/ppo_balancer) agents.
 
     \note For reinforcement learning with neural networks: the observation
     space and action space are not normalized.
@@ -36,49 +41,35 @@ class UpkieGroundVelocity(UpkieBaseEnv):
     The action corresponds to the ground velocity resulting from wheel
     velocities. The action vector is simply:
 
-    <table>
-        <tr>
-            <td><strong>Index</strong></td>
-            <td><strong>Description</strong></td>
-            </tr>
-        <tr>
-            <td>``0``</td>
-            <td>Ground velocity in [m] / [s].</td>
-        </tr>
-    </table>
+    \f[
+    a =\begin{bmatrix} \dot{p}^* \end{bmatrix}
+    \f]
 
-    Note that, while this action is not normalized, [-1, 1] m/s is a reasonable
-    range for ground velocities.
+    where we denote by \f$\dot{p}^*\f$ the commanded ground velocity in [m] /
+    [s], which is internally converted into wheel velocity commands. Note that,
+    while this action is not normalized, [-1, 1] m/s is a reasonable range for
+    ground velocities.
 
     ### Observation space
 
     Vectorized observations have the following structure:
 
-    <table>
-        <tr>
-            <td><strong>Index</strong></td>
-            <td><strong>Description</strong></td>
-        </tr>
-        <tr>
-            <td>0</td>
-            <td>Pitch angle of the base with respect to the world vertical, in
-            radians. This angle is positive when the robot leans forward.</td>
-        </tr>
-        <tr>
-            <td>1</td>
-            <td>Position of the average wheel contact point, in meters.</td>
-        </tr>
-        <tr>
-            <td>2</td>
-            <td>Body angular velocity of the base frame along its lateral axis,
-            in radians per seconds.</td>
-        </tr>
-        <tr>
-            <td>3</td>
-            <td>Velocity of the average wheel contact point, in meters per
-            seconds.</td>
-        </tr>
-    </table>
+    \f[
+    \begin{align*}
+    o &= \begin{bmatrix} \theta \\ p \\ \dot{\theta} \\ \dot{p} \end{bmatrix}
+    \end{align*}
+    \f]
+
+    where we denote by:
+
+    - \f$\theta\f$ the pitch angle of the base with respect to the world
+      vertical, in radians. This angle is positive when the robot leans
+      forward.
+    - \f$p\f$ the position of the average wheel contact point, in meters.
+    - \f$\dot{\theta}\f$ the body angular velocity of the base frame along its
+      lateral axis, in radians per seconds.
+    - \f$\dot{p}\f$ the velocity of the average wheel contact point, in meters
+      per seconds.
 
     As with all Upkie environments, full observations from the spine (detailed
     in \ref observations) are also available in the `info` dictionary

--- a/upkie/envs/upkie_servo_positions.py
+++ b/upkie/envs/upkie_servo_positions.py
@@ -17,15 +17,32 @@ class UpkieServoPositions(UpkieServos):
     r"""!
     Command servos by position control.
 
-    Child class of UpkieServos that defines the action space as a dictionary of
-    joint names with the following keys:
+    \anchor upkie_servo_positions_description
 
-    - `position`: the desired position of the joint
-    - `kp_scale`: the proportional gain of the joint
-    - `kd_scale`: the derivative gain of the joint
+    ### Action space
 
-    Which simplifies the control of the robot by allowing to control the
-    position of the joints and the gains.
+    The action space is consists of the following targets for each joint:
+
+    - `position`: commanded joint angle \f$\theta^*\f$ in [rad] (NaN to
+       disable) (required).
+    - `kp_scale`: scaling factor \f$k_{p}^{\mathit{scale}}\f$ applied to the
+       position feedback gain, between zero and one.
+    - `kd_scale`: scaling factor \f$k_{d}^{\mathit{scale}}\f$ applied to the
+       velocity feedback gain, between zero and one.
+
+    This makes the agent command servo positions with velocity damping:
+
+    \f[
+    \begin{align*}
+    \tau & = k_{p} k_{p}^{\mathit{scale}} (\theta^* - \theta) - k_{d}
+    k_{d}^{\mathit{scale}} \dot{\theta}
+    \end{align*}
+    \f]
+
+    ### Observation space
+
+    This environment has the same observation space as [UpkieServos](\ref
+    upkie_servos_description).
     """
 
     ACTION_MASK: Set[str] = set(["position", "kp_scale", "kd_scale"])

--- a/upkie/envs/upkie_servo_torques.py
+++ b/upkie/envs/upkie_servo_torques.py
@@ -14,16 +14,28 @@ from .upkie_servos import UpkieServos
 
 
 class UpkieServoTorques(UpkieServos):
-    """!
+    r"""!
     Command servos by torque control.
 
-    Child class of UpkieServos that defines the action space as a dictionary of
-    joint names with the following key :
+    \anchor upkie_servo_torques_description
 
-    - `feedforward_torque`: the desired feedforward torque of the joint
+    The action space is consists of the following targets for each joint:
 
-    Which simplifies the control of the robot by allowing to control directly
-    the torque of the joints.
+    - `feedforward_torque`: feedforward joint torque \f$\tau_{\mathit{ff}}\f$
+       in [N m].
+
+    This makes the agent command joint torques directly:
+
+    \f[
+    \begin{align*}
+    \tau & = \tau_{\mathit{ff}}
+    \end{align*}
+    \f]
+
+    ### Observation space
+
+    This environment has the same observation space as [UpkieServos](\ref
+    upkie_servos_description).
     """
 
     ACTION_MASK: Set[str] = set(["feedforward_torque"])

--- a/upkie/envs/upkie_servos.py
+++ b/upkie/envs/upkie_servos.py
@@ -25,29 +25,29 @@ class UpkieServos(UpkieBaseEnv):
 
     The action space is a dictionary with one key for each servo:
 
-    - `left_hip`: Left hip joint (qdd100)
-    - `left_hip`: Left knee joint (qdd100)
-    - `left_hip`: Left wheel joint (mj5208)
-    - `right_hip`: Right hip joint (qdd100)
-    - `right_hip`: Right knee joint (qdd100)
-    - `right_hip`: Right wheel joint (mj5208)
+    - `left_hip`: left hip joint (qdd100)
+    - `left_hip`: left knee joint (qdd100)
+    - `left_hip`: left wheel joint (mj5208)
+    - `right_hip`: right hip joint (qdd100)
+    - `right_hip`: right knee joint (qdd100)
+    - `right_hip`: right wheel joint (mj5208)
 
     The value for each servo dictionary is itself a dictionary with the
     following keys:
 
-    - `position`: Commanded joint angle \f$\theta^*\f$ in [rad] (NaN to
-        disable) (required).
-    - `velocity`: Commanded joint velocity \f$\dot{\theta}^*\f$ in [rad] /
-        [s] (required).
-    - `feedforward_torque`: Feedforward joint torque \f$\tau_{\mathit{ff}}\f$
-        in [N m].
-    - `kp_scale`: Scaling factor \f$k_{p}^{\mathit{scale}}\f$ applied to the
-        position feedback gain, between zero and one.
-    - `kd_scale`: Scaling factor \f$k_{d}^{\mathit{scale}}\f$ applied to the
-        velocity feedback gain, between zero and one.
-    - `maximum_torque`: Maximum joint torque \f$\tau_{\mathit{max}}\f$
-        (feedforward + feedback) enforced during the whole actuation step, in
-        [N m].
+    - `position`: commanded joint angle \f$\theta^*\f$ in [rad] (NaN to
+       disable) (required).
+    - `velocity`: commanded joint velocity \f$\dot{\theta}^*\f$ in [rad] /
+       [s] (required).
+    - `feedforward_torque`: feedforward joint torque \f$\tau_{\mathit{ff}}\f$
+       in [N m].
+    - `kp_scale`: scaling factor \f$k_{p}^{\mathit{scale}}\f$ applied to the
+       position feedback gain, between zero and one.
+    - `kd_scale`: scaling factor \f$k_{d}^{\mathit{scale}}\f$ applied to the
+       velocity feedback gain, between zero and one.
+    - `maximum_torque`: maximum joint torque \f$\tau_{\mathit{max}}\f$
+       (feedforward + feedback) enforced during the whole actuation step, in
+       [N m].
 
     The resulting torque applied by the servo is then:
 

--- a/upkie/envs/upkie_servos.py
+++ b/upkie/envs/upkie_servos.py
@@ -19,6 +19,8 @@ class UpkieServos(UpkieBaseEnv):
     r"""!
     Upkie with with action and observation for each servo.
 
+    \anchor upkie_servos_description
+
     ### Action space
 
     The action space is a dictionary with one key for each servo:
@@ -63,9 +65,13 @@ class UpkieServos(UpkieBaseEnv):
     \end{align*}
     \f]
 
-    Note that the servo regulates the torque above at its own frequency, which
-    is higher (typically 40 kHz) than the agent and the spine frequencies. See
-    the [moteus
+    Position and velocity gains \f$k_{p}\f$ and \f$k_{d}\f$ are configured in
+    each moteus controller directly and don't change during execution. We can
+    rather modulate the overall feedback gains via the normalized parameters
+    \f$k_{p}^{\mathit{scale}} \in [0, 1]\f$ and \f$k_{d}^{\mathit{scale}} \in
+    [0, 1]\f$. Note that the servo regulates the torque above at its own
+    frequency, which is higher (typically 40 kHz) than the agent and the spine
+    frequencies. See the [moteus
     reference](https://github.com/mjbots/moteus/blob/13c171c697ce6f60a73c9385e6fe951957313d1d/docs/reference.md#theory-of-operation)
     for more details.
 

--- a/upkie/envs/upkie_servos.py
+++ b/upkie/envs/upkie_servos.py
@@ -17,7 +17,7 @@ from .upkie_base_env import UpkieBaseEnv
 
 class UpkieServos(UpkieBaseEnv):
     r"""!
-    Upkie with with action and observation for each servo.
+    Upkie with actions and observations corresponding to the moteus servo API.
 
     \anchor upkie_servos_description
 


### PR DESCRIPTION
Previously we duplicated environment descriptions (1) on the environment page and (2) in each environment.

This PR turns the environment page into an index, with direct links inside each environment's documentation so that readers end up directly on the better-formatted part.