### PR TITLE
Rename `LowPassFilterAction` to `AddLagToAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CICD: Pin Ubuntu workflows to 22.04
-- Default `kd` gain for wheel servos is now 0.3
-- Move Python spine exceptions to `upkie.exceptions`
-- docs: Turn environment page into an index
-- tools: Make output directory an argument in `dump_servo_configs`
-- tools: Simplify servo configuration script
 - **Breaking:** Spine and spine interface revisions:
     - Observations are now returned upon reset and step
     - Spine: Remove separate observation state and observation request
@@ -28,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - SpineInterface: Starting the spine now returns an observation
     - StateMachine: Rename spine FSM state from "act" to "step"
     - docs: Update spine FSM specification in the documentation
+- **Breaking:** envs: Rename `LowPassFilterAction` to `AddLagToAction`
+- CICD: Pin Ubuntu workflows to 22.04
+- Default `kd` gain for wheel servos is now 0.3
+- Move Python spine exceptions to `upkie.exceptions`
+- docs: Turn environment page into an index
+- tools: Make output directory an argument in `dump_servo_configs`
+- tools: Simplify servo configuration script
 
 ### Fixed
 

--- a/upkie/envs/wrappers/BUILD
+++ b/upkie/envs/wrappers/BUILD
@@ -11,8 +11,8 @@ py_library(
     srcs = [
         "__init__.py",
         "add_action_to_observation.py",
+        "add_lag_to_action.py",
         "differentiate_action.py",
-        "low_pass_filter_action.py",
         "noisify_action.py",
         "noisify_observation.py",
         "random_push.py",

--- a/upkie/envs/wrappers/__init__.py
+++ b/upkie/envs/wrappers/__init__.py
@@ -6,16 +6,16 @@
 
 from .add_action_to_observation import AddActionToObservation
 from .differentiate_action import DifferentiateAction
-from .low_pass_filter_action import LowPassFilterAction
+from .add_lag_to_action import AddLagToAction
 from .noisify_action import NoisifyAction
 from .noisify_observation import NoisifyObservation
 from .random_push import RandomPush
 
 __all__ = [
     "AddActionToObservation",
+    "AddLagToAction",
     "DifferentiateAction",
-    "LowPassFilterAction",
     "NoisifyAction",
     "NoisifyObservation",
-    "RandomPush"
+    "RandomPush",
 ]

--- a/upkie/envs/wrappers/__init__.py
+++ b/upkie/envs/wrappers/__init__.py
@@ -5,8 +5,8 @@
 # Copyright 2023 Inria
 
 from .add_action_to_observation import AddActionToObservation
-from .differentiate_action import DifferentiateAction
 from .add_lag_to_action import AddLagToAction
+from .differentiate_action import DifferentiateAction
 from .noisify_action import NoisifyAction
 from .noisify_observation import NoisifyObservation
 from .random_push import RandomPush

--- a/upkie/envs/wrappers/add_lag_to_action.py
+++ b/upkie/envs/wrappers/add_lag_to_action.py
@@ -20,10 +20,10 @@ class AddLagToAction(gymnasium.Wrapper):
     Note that there is a difference between "delay" and "lag":
 
     - Delay is a fixed time interval corresponding to the time it takes the
-      input to affect the output, e.g. `input[t] = output[t + delay]`.
+      input to affect the output, e.g. `output(t + delay) = input(t)`.
     - Lag is a phase shift in the system's response. It can be thought of as a
       gradual response to input changes where the output does not immediately
-      match the input.
+      match the input, e.g. `d/dt{output}(t) = lag * (input(t) - output(t))`.
 
     In this wrapper, we model lag where the output (action forward to the
     wrapped environment) is a low-pass filtered version of the input (action

--- a/upkie/envs/wrappers/add_lag_to_action.py
+++ b/upkie/envs/wrappers/add_lag_to_action.py
@@ -13,9 +13,21 @@ from gymnasium.spaces import Box
 from upkie.utils.filters import low_pass_filter
 
 
-class LowPassFilterAction(gymnasium.Wrapper):
+class AddLagToAction(gymnasium.Wrapper):
     """!
-    Apply a low-pass filter to the action of an environment.
+    Model lag by applying a low-pass filter to the action of an environment.
+
+    Note that there is a difference between "delay" and "lag":
+
+    - Delay is a fixed time interval corresponding to the time it takes the
+      input to affect the output, e.g. `input[t] = output[t + delay]`.
+    - Lag is a phase shift in the system's response. It can be thought of as a
+      gradual response to input changes where the output does not immediately
+      match the input.
+
+    In this wrapper, we model lag where the output (action forward to the
+    wrapped environment) is a low-pass filtered version of the input (action
+    passed to `step`).
     """
 
     ## \var filtered_action
@@ -36,7 +48,7 @@ class LowPassFilterAction(gymnasium.Wrapper):
         Initialize wrapper.
 
         \param env Environment to wrap.
-        \param time_constant Cutoff period in seconds of a low-pass filter
+        \param time_constant Cutoff period in seconds of the low-pass filter
             applied to the action. If a Box is provided, couple of lower and
             upper bounds for the action: a new time constant is sampled
             uniformly at random between these bounds at every reset of the

--- a/upkie/envs/wrappers/add_lag_to_action.py
+++ b/upkie/envs/wrappers/add_lag_to_action.py
@@ -25,7 +25,7 @@ class AddLagToAction(gymnasium.Wrapper):
       gradual response to input changes where the output does not immediately
       match the input, e.g. `d/dt{output}(t) = lag * (input(t) - output(t))`.
 
-    In this wrapper, we model lag where the output (action forward to the
+    In this wrapper, we model *lag* where the output (action forward to the
     wrapped environment) is a low-pass filtered version of the input (action
     passed to `step`).
     """

--- a/upkie/envs/wrappers/tests/BUILD
+++ b/upkie/envs/wrappers/tests/BUILD
@@ -30,8 +30,8 @@ py_test(
 )
 
 py_test(
-    name = "low_pass_filter_action_test",
-    srcs = ["low_pass_filter_action_test.py"],
+    name = "add_lag_to_action_test",
+    srcs = ["add_lag_to_action_test.py"],
     deps = [
         "//upkie/envs/wrappers",
         ":envs",

--- a/upkie/envs/wrappers/tests/add_lag_to_action_test.py
+++ b/upkie/envs/wrappers/tests/add_lag_to_action_test.py
@@ -11,14 +11,14 @@ import unittest
 import gymnasium
 import numpy as np
 
-from upkie.envs.wrappers.low_pass_filter_action import LowPassFilterAction
+from upkie.envs.wrappers.add_lag_to_action import AddLagToAction
 from upkie.envs.wrappers.tests.envs import ActionObserverEnv
 
 
-class LowPassFilterActionTestCase(unittest.TestCase):
+class AddLagToActionTestCase(unittest.TestCase):
     def test_lpf(self):
         env = ActionObserverEnv()
-        lpf_env = LowPassFilterAction(env, time_constant=1.0)
+        lpf_env = AddLagToAction(env, time_constant=1.0)
         action = np.array([1.0])
         inner_action, _, _, _, _ = lpf_env.step(action)
         self.assertTrue(np.allclose(action * env.unwrapped.dt, inner_action))
@@ -28,7 +28,7 @@ class LowPassFilterActionTestCase(unittest.TestCase):
             from stable_baselines3.common.env_checker import check_env
 
             env = gymnasium.make("Pendulum-v1")
-            lpf_env = LowPassFilterAction(env, time_constant=1.0)
+            lpf_env = AddLagToAction(env, time_constant=1.0)
             check_env(lpf_env)
         except ImportError:
             pass


### PR DESCRIPTION
The new name follows the convention where wrappers are named `DoSomethingToSomething`.