### PR TITLE
Add robot links mass randomization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added upkie links mass randomization
 - Handle GLIBC version incompatibility in `start_simulation.sh`
 - Update downloaded simulation spine in cache if outdated
 - actuation: Check maximum torques before sending commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added upkie links mass randomization
+- actuation: Added link inertia randomization to the Bullet interface
 - Handle GLIBC version incompatibility in `start_simulation.sh`
 - Update downloaded simulation spine in cache if outdated
 - actuation: Check maximum torques before sending commands

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -158,7 +158,7 @@ class CommandLineArguments {
   //! Spine frequency in Hz.
   unsigned spine_frequency = 1000u;
 
-  //! Mass randomization epsilon
+  //! Mass randomization ratio in [%]
   double mass_randomization_epsilon = 0.0;
 
   //! Version flag

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -80,7 +80,7 @@ class CommandLineArguments {
         spdlog::info("Command line: robot_variant = {}", robot_variant);
       } else if (arg == "--mass-randomization-epsilon") {
         mass_randomization_epsilon = std::stod(args.at(++i));
-        spdlog::info("Command line: mass_randomization_epsilon = {}",
+        spdlog::info("Command line: mass_randomization_epsilon = {} [kg]",
                      mass_randomization_epsilon);
       } else {
         spdlog::error("Unknown argument: {}", arg);

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -78,10 +78,10 @@ class CommandLineArguments {
       } else if (arg == "--robot-variant") {
         robot_variant = args.at(++i);
         spdlog::info("Command line: robot_variant = {}", robot_variant);
-      } else if (arg == "--mass-randomization-epsilon") {
-        mass_randomization_epsilon = std::stod(args.at(++i));
-        spdlog::info("Command line: mass_randomization_epsilon = {} [kg]",
-                     mass_randomization_epsilon);
+      } else if (arg == "--inertia-randomization") {
+        inertia_randomization = std::stod(args.at(++i));
+        spdlog::info("Command line: inertia_randomization = {} [kg]",
+                     inertia_randomization);
       } else {
         spdlog::error("Unknown argument: {}", arg);
         error = true;
@@ -120,8 +120,8 @@ class CommandLineArguments {
               << "    Spine frequency in Hertz (default: 1000 Hz).\n";
     std::cout << "--robot-variant <variant>\n"
               << "    Robot variant (default: '').\n";
-    std::cout << "--mass-randomization-epsilon <epsilon>\n"
-              << "    Randomize masses of the robot links.\n";
+    std::cout << "--inertia-randomization <epsilon>\n"
+              << "    Randomize inertia of the robot links.\n";
     std::cout << "-v, --version\n"
               << "    Print out the spine version number.\n";
     std::cout << "\n";
@@ -159,7 +159,7 @@ class CommandLineArguments {
   unsigned spine_frequency = 1000u;
 
   //! Mass randomization ratio in [%]
-  double mass_randomization_epsilon = 0.0;
+  double inertia_randomization = 0.0;
 
   //! Version flag
   bool version = false;
@@ -241,7 +241,7 @@ int main(const char* argv0, const CommandLineArguments& args) {
   bullet_params.floor = !args.space;
   bullet_params.gravity = !args.space;
   bullet_params.gui = args.show;
-  bullet_params.mass_randomization_epsilon = args.mass_randomization_epsilon;
+  bullet_params.inertia_randomization = args.inertia_randomization;
   bullet_params.position_base_in_world = Eigen::Vector3d(0., 0., base_altitude);
   if (args.robot_variant.empty()) {
     bullet_params.robot_urdf_path =

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -78,7 +78,7 @@ class CommandLineArguments {
       } else if (arg == "--robot-variant") {
         robot_variant = args.at(++i);
         spdlog::info("Command line: robot_variant = {}", robot_variant);
-      } else if (arg == "Command line: mass_randomization_epsilon = {}") {
+      } else if (arg == "--mass-randomization-epsilon") {
         mass_randomization_epsilon = std::stod(args.at(++i));
         spdlog::info("Command line: mass_randomization_epsilon = {}",
                      mass_randomization_epsilon);

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -78,6 +78,10 @@ class CommandLineArguments {
       } else if (arg == "--robot-variant") {
         robot_variant = args.at(++i);
         spdlog::info("Command line: robot_variant = {}", robot_variant);
+      } else if (arg == "Command line: mass_randomization_epsilon = {}") {
+        mass_randomization_epsilon = std::stod(args.at(++i));
+        spdlog::info("Command line: mass_randomization_epsilon = {}",
+                     mass_randomization_epsilon);
       } else {
         spdlog::error("Unknown argument: {}", arg);
         error = true;
@@ -116,6 +120,8 @@ class CommandLineArguments {
               << "    Spine frequency in Hertz (default: 1000 Hz).\n";
     std::cout << "--robot-variant <variant>\n"
               << "    Robot variant (default: '').\n";
+    std::cout << "--mass-randomization-epsilon <epsilon>\n"
+              << "    Randomize masses of the robot links.\n";
     std::cout << "-v, --version\n"
               << "    Print out the spine version number.\n";
     std::cout << "\n";
@@ -151,6 +157,9 @@ class CommandLineArguments {
 
   //! Spine frequency in Hz.
   unsigned spine_frequency = 1000u;
+
+  //! Mass randomization epsilon
+  double mass_randomization_epsilon = 0.0;
 
   //! Version flag
   bool version = false;
@@ -232,6 +241,7 @@ int main(const char* argv0, const CommandLineArguments& args) {
   bullet_params.floor = !args.space;
   bullet_params.gravity = !args.space;
   bullet_params.gui = args.show;
+  bullet_params.mass_randomization_epsilon = args.mass_randomization_epsilon;
   bullet_params.position_base_in_world = Eigen::Vector3d(0., 0., base_altitude);
   if (args.robot_variant.empty()) {
     bullet_params.robot_urdf_path =

--- a/upkie/cpp/actuation/BUILD
+++ b/upkie/cpp/actuation/BUILD
@@ -77,8 +77,10 @@ cc_library(
     name = "bullet_interface",
     hdrs = [
         "BulletInterface.h",
+        "RobotSimulator.h"
     ],
     srcs = [
+        "RobotSimulator.cpp",
         "BulletInterface.cpp",
     ],
     data = [
@@ -95,6 +97,18 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = 'robot_simulator',
+    hdrs = [
+        'RobotSimulator.h',
+    ],
+    srcs = [
+        'RobotSimulator.cpp',
+    ],
+    deps = [
+        "@bullet"
+    ],
+)
 cc_library(
     name = "pi3hat_interface",
     hdrs = [

--- a/upkie/cpp/actuation/BUILD
+++ b/upkie/cpp/actuation/BUILD
@@ -106,7 +106,8 @@ cc_library(
         'RobotSimulator.cpp',
     ],
     deps = [
-        "@bullet"
+        "@bullet",
+        "@eigen"
     ],
 )
 cc_library(

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -57,7 +57,7 @@ BulletInterface::BulletInterface(const Parameters& params)
   if (imu_link_index_ < 0) {
     throw std::runtime_error("Robot does not have a link named \"imu\"");
   }
-  // If params has an attribute mass_randomization_epsilon, store nominal masses 
+  // If params has an attribute mass_randomization_epsilon, store masses
   if (params.mass_randomization_epsilon) {
     mass_randomization_epsilon_ = params.mass_randomization_epsilon;
     get_nominal_masses();
@@ -362,29 +362,31 @@ void BulletInterface::read_joint_sensors() {
   }
 }
 void BulletInterface::get_nominal_masses() {
-  const int nb_links = bullet_.getNumJoints(robot_) ;
-  b3DynamicsInfo info ;
-  for (int link_id = 0; link_id < nb_links; ++link_id){
-    bullet_.getDynamicsInfo(robot_, link_id,&info); 
+  const int nb_links = bullet_.getNumJoints(robot_);
+  b3DynamicsInfo info;
+  for (int link_id = 0; link_id < nb_links; ++link_id) {
+    bullet_.getDynamicsInfo(robot_, link_id, &info);
     nominal_masses[link_id] = info.m_mass;
     for (int i = 0; i < 3; ++i) {
         nominal_inertia[link_id][i] = info.m_localInertialDiagonal[i];
     }
-    
   }
 }
 void BulletInterface::randomize_masses() {
   for (const auto& link_id : nominal_masses) {
     std::default_random_engine generator;
-    std::uniform_real_distribution<double> distribution(-mass_randomization_epsilon_, mass_randomization_epsilon_);
+    std::uniform_real_distribution<double> distribution(
+      -mass_randomization_epsilon_,
+      mass_randomization_epsilon_);
     double epsilon = distribution(generator);
     RobotSimulatorChangeDynamicsArgs change_dyn_args;
     change_dyn_args.m_mass = nominal_masses[link_id.first] * (1+epsilon);
     for (int i = 0; i < 3; ++i) {
-        change_dyn_args.m_localInertiaDiagonal[i] = nominal_inertia[link_id.first][i] * (1 + epsilon);
+        change_dyn_args.m_localInertiaDiagonal[i] =
+          nominal_inertia[link_id.first][i] * (1 + epsilon);
     }
 
-    bullet_.changeDynamics(robot_, link_id.first, change_dyn_args) ;
+    bullet_.changeDynamics(robot_, link_id.first, change_dyn_args);
   }
 }
 

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -368,7 +368,7 @@ void BulletInterface::get_nominal_masses() {
     bullet_.getDynamicsInfo(robot_, link_id, &info);
     nominal_masses[link_id] = info.m_mass;
     for (int i = 0; i < 3; ++i) {
-        nominal_inertia[link_id][i] = info.m_localInertialDiagonal[i];
+      nominal_inertia[link_id][i] = info.m_localInertialDiagonal[i];
     }
   }
 }
@@ -376,13 +376,12 @@ void BulletInterface::randomize_masses() {
   for (const auto& link_id : nominal_masses) {
     std::default_random_engine generator;
     std::uniform_real_distribution<double> distribution(
-      -mass_randomization_epsilon_,
-      mass_randomization_epsilon_);
+        -mass_randomization_epsilon_, mass_randomization_epsilon_);
     double epsilon = distribution(generator);
     RobotSimulatorChangeDynamicsArgs change_dyn_args;
-    change_dyn_args.m_mass = nominal_masses[link_id.first] * (1+epsilon);
+    change_dyn_args.m_mass = nominal_masses[link_id.first] * (1 + epsilon);
     for (int i = 0; i < 3; ++i) {
-        change_dyn_args.m_localInertiaDiagonal[i] =
+      change_dyn_args.m_localInertiaDiagonal[i] =
           nominal_inertia[link_id.first][i] * (1 + epsilon);
     }
 

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -362,12 +362,14 @@ void BulletInterface::read_joint_sensors() {
   }
 }
 void BulletInterface::get_nominal_masses() {
-  const int nb_links = bullet_.getNumJoints(robot_) + 1;
+  const int nb_links = bullet_.getNumJoints(robot_) ;
   b3DynamicsInfo info ;
   for (int link_id = 0; link_id < nb_links; ++link_id){
-    bool _ =  bullet_.getDynamicsInfo(robot_, link_id,&info); 
+    bullet_.getDynamicsInfo(robot_, link_id,&info); 
     nominal_masses[link_id] = info.m_mass;
-    nominal_inertia[link_id] = Eigen::Map<Eigen::Vector3d>(info.m_localInertialDiagonal);
+    for (int i = 0; i < 3; ++i) {
+        nominal_inertia[link_id][i] = info.m_localInertialDiagonal[i];
+    }
     
   }
 }
@@ -378,7 +380,10 @@ void BulletInterface::randomize_masses() {
     double epsilon = distribution(generator);
     RobotSimulatorChangeDynamicsArgs change_dyn_args;
     change_dyn_args.m_mass = nominal_masses[link_id.first] * (1+epsilon);
-    change_dyn_args.m_localInertiaDiagonal = nominal_inertia[link_id.first] * (1+epsilon);
+    for (int i = 0; i < 3; ++i) {
+        change_dyn_args.m_localInertiaDiagonal[i] = nominal_inertia[link_id.first][i] * (1 + epsilon);
+    }
+
     bullet_.changeDynamics(robot_, link_id.first, change_dyn_args) ;
   }
 }

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -385,8 +385,8 @@ void BulletInterface::randomize_masses() {
     double epsilon1 = distribution01(generator);
     double epsilon2 = distribution01(generator);
     epsilon0 = epsilon * epsilon0 / (epsilon0 + epsilon1 + epsilon2);
-    epsilon1 = epsilon * epsilon0 / (epsilon0 + epsilon1 + epsilon2);
-    epsilon2 = epsilon * epsilon0 / (epsilon0 + epsilon1 + epsilon2);
+    epsilon1 = epsilon * epsilon1 / (epsilon0 + epsilon1 + epsilon2);
+    epsilon2 = epsilon * epsilon2 / (epsilon0 + epsilon1 + epsilon2);
     change_dyn_args.m_localInertiaDiagonal[0] =
         nominal_inertia[link_id.first][0] * (1 + epsilon0);
     change_dyn_args.m_localInertiaDiagonal[1] =

--- a/upkie/cpp/actuation/BulletInterface.cpp
+++ b/upkie/cpp/actuation/BulletInterface.cpp
@@ -60,7 +60,7 @@ BulletInterface::BulletInterface(const Parameters& params)
   // If params has an attribute mass_randomization_epsilon, store masses
   if (params.mass_randomization_epsilon) {
     mass_randomization_epsilon_ = params.mass_randomization_epsilon;
-    get_nominal_masses();
+    save_nominal_masses();
   }
 
   // Read servo layout

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -12,7 +12,9 @@
 #include <string>
 #include <vector>
 
-#include "RobotSimulator/b3RobotSimulatorClientAPI.h"
+//#include "RobotSimulator/b3RobotSimulatorClientAPI.h"
+#include "upkie/cpp/actuation/RobotSimulator.h"
+#include "SharedMemory/PhysicsClientC_API.h"
 #include "upkie/cpp/actuation/ImuUncertainty.h"
 #include "upkie/cpp/actuation/Interface.h"
 #include "upkie/cpp/actuation/bullet/ContactData.h"
@@ -122,6 +124,9 @@ class BulletInterface : public Interface {
     //! Translate the camera to follow the robot
     bool follower_camera = false;
 
+    //! Mass randomization epsilon
+    double mass_randomization_epsilon = 0.0;
+    
     //! If true, set gravity to -9.81 m/s².
     bool gravity = true;
 
@@ -353,6 +358,12 @@ class BulletInterface : public Interface {
   //! Convenience function to follow the base translation
   void translate_camera_to_robot();
 
+  //! Randomize masses of the robot links
+  void randomize_masses();
+
+  //! Get nominal masses of the robot links
+  void get_nominal_masses();
+
  private:
   //! Interface parameters
   Parameters params_;
@@ -381,6 +392,14 @@ class BulletInterface : public Interface {
   //! Map from link name to link index in Bullet
   std::map<std::string, int> link_index_;
 
+  //! Nominal masses of the robot links
+  std::map<int, double> nominal_masses;
+
+  //! Nominal inertia diagonal of the robot links
+  std::map<int, Eigen::Vector3d> nominal_inertia;
+
+  //! Mass randomization epsilon
+  double mass_randomization_epsilon_;
   //! Map from link name to link contact data
   std::map<std::string, bullet::ContactData> contact_data_;
 

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "SharedMemory/PhysicsClientC_API.h"
 #include "upkie/cpp/actuation/ImuUncertainty.h"
 #include "upkie/cpp/actuation/Interface.h"
 #include "upkie/cpp/actuation/RobotSimulator.h"

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -12,10 +12,10 @@
 #include <string>
 #include <vector>
 
-#include "upkie/cpp/actuation/RobotSimulator.h"
 #include "SharedMemory/PhysicsClientC_API.h"
 #include "upkie/cpp/actuation/ImuUncertainty.h"
 #include "upkie/cpp/actuation/Interface.h"
+#include "upkie/cpp/actuation/RobotSimulator.h"
 #include "upkie/cpp/actuation/bullet/ContactData.h"
 #include "upkie/cpp/actuation/bullet/ExternalForce.h"
 #include "upkie/cpp/actuation/bullet/JointProperties.h"

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -123,7 +123,7 @@ class BulletInterface : public Interface {
     bool follower_camera = false;
 
     //! Mass randomization epsilon
-    double mass_randomization_epsilon = 0.0;
+    double inertia_randomization = 0.0;
 
     //! If true, set gravity to -9.81 m/s².
     bool gravity = true;
@@ -326,13 +326,13 @@ class BulletInterface : public Interface {
   Eigen::Vector3d get_position_link_in_world(const std::string& link_name);
 
   //! Get nominal masses of the robot links
-  void get_nominal_masses();
+  void save_nominal_masses();
 
   //! Randomize masses of the robot links
   void randomize_masses();
 
   //! Mass randomization epsilon
-  double mass_randomization_epsilon_;
+  double inertia_randomization_;
 
   //! Nominal masses of the robot links
   std::map<int, double> nominal_masses;

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-//#include "RobotSimulator/b3RobotSimulatorClientAPI.h"
 #include "upkie/cpp/actuation/RobotSimulator.h"
 #include "SharedMemory/PhysicsClientC_API.h"
 #include "upkie/cpp/actuation/ImuUncertainty.h"
@@ -126,7 +125,7 @@ class BulletInterface : public Interface {
 
     //! Mass randomization epsilon
     double mass_randomization_epsilon = 0.0;
-    
+
     //! If true, set gravity to -9.81 m/s².
     bool gravity = true;
 
@@ -327,6 +326,21 @@ class BulletInterface : public Interface {
    */
   Eigen::Vector3d get_position_link_in_world(const std::string& link_name);
 
+  //! Get nominal masses of the robot links
+  void get_nominal_masses();
+
+  //! Randomize masses of the robot links
+  void randomize_masses();
+
+  //! Mass randomization epsilon
+  double mass_randomization_epsilon_;
+
+  //! Nominal masses of the robot links
+  std::map<int, double> nominal_masses;
+
+  //! Nominal inertia diagonal of the robot links
+  std::map<int, double[3]> nominal_inertia;
+
  private:
   //! Apply external forces.
   void apply_external_forces();
@@ -358,12 +372,6 @@ class BulletInterface : public Interface {
   //! Convenience function to follow the base translation
   void translate_camera_to_robot();
 
-  //! Randomize masses of the robot links
-  void randomize_masses();
-
-  //! Get nominal masses of the robot links
-  void get_nominal_masses();
-
  private:
   //! Interface parameters
   Parameters params_;
@@ -392,14 +400,6 @@ class BulletInterface : public Interface {
   //! Map from link name to link index in Bullet
   std::map<std::string, int> link_index_;
 
-  //! Nominal masses of the robot links
-  std::map<int, double> nominal_masses;
-
-  //! Nominal inertia diagonal of the robot links
-  std::map<int, double[3]> nominal_inertia;
-
-  //! Mass randomization epsilon
-  double mass_randomization_epsilon_;
   //! Map from link name to link contact data
   std::map<std::string, bullet::ContactData> contact_data_;
 

--- a/upkie/cpp/actuation/BulletInterface.h
+++ b/upkie/cpp/actuation/BulletInterface.h
@@ -375,7 +375,7 @@ class BulletInterface : public Interface {
   std::map<std::string, moteus::ServoReply> servo_reply_;
 
   //! Bullet client
-  b3RobotSimulatorClientAPI bullet_;
+  RobotSimulatorClientAPI bullet_;
 
   //! Identifier of the robot model in the simulation
   int robot_;
@@ -396,7 +396,7 @@ class BulletInterface : public Interface {
   std::map<int, double> nominal_masses;
 
   //! Nominal inertia diagonal of the robot links
-  std::map<int, Eigen::Vector3d> nominal_inertia;
+  std::map<int, double[3]> nominal_inertia;
 
   //! Mass randomization epsilon
   double mass_randomization_epsilon_;

--- a/upkie/cpp/actuation/RobotSimulator.cpp
+++ b/upkie/cpp/actuation/RobotSimulator.cpp
@@ -1,0 +1,67 @@
+#include "RobotSimulator.h"
+#include <iostream>  // For error logging or debugging
+
+bool RobotSimulatorClientAPI::changeDynamics(int bodyUniqueId, int linkIndex, struct RobotSimulatorChangeDynamicsArgs& args)
+{
+	b3PhysicsClientHandle sm = m_data->m_physicsClientHandle;
+	if (sm == 0)
+	{
+		b3Warning("Not connected to physics server.");
+		return false;
+	}
+	b3SharedMemoryCommandHandle command = b3InitChangeDynamicsInfo(sm);
+	b3SharedMemoryStatusHandle statusHandle;
+
+	if (args.m_activationState >= 0)
+	{
+		b3ChangeDynamicsInfoSetActivationState(command, bodyUniqueId, args.m_activationState);
+	}
+	if (args.m_mass >= 0)
+	{
+		b3ChangeDynamicsInfoSetMass(command, bodyUniqueId, linkIndex, args.m_mass);
+	}
+    if (!(args.m_localInertiaDiagonal[0] == 0 && args.m_localInertiaDiagonal[1] == 0 && args.m_localInertiaDiagonal[2] == 0)) {
+        b3ChangeDynamicsInfoSetLocalInertiaDiagonal(command, bodyUniqueId, linkIndex, args.m_localInertiaDiagonal);
+    }
+	if (args.m_lateralFriction >= 0)
+	{
+		b3ChangeDynamicsInfoSetLateralFriction(command, bodyUniqueId, linkIndex, args.m_lateralFriction);
+	}
+
+	if (args.m_spinningFriction >= 0)
+	{
+		b3ChangeDynamicsInfoSetSpinningFriction(command, bodyUniqueId, linkIndex, args.m_spinningFriction);
+	}
+
+	if (args.m_rollingFriction >= 0)
+	{
+		b3ChangeDynamicsInfoSetRollingFriction(command, bodyUniqueId, linkIndex, args.m_rollingFriction);
+	}
+
+	if (args.m_linearDamping >= 0)
+	{
+		b3ChangeDynamicsInfoSetLinearDamping(command, bodyUniqueId, args.m_linearDamping);
+	}
+
+	if (args.m_angularDamping >= 0)
+	{
+		b3ChangeDynamicsInfoSetAngularDamping(command, bodyUniqueId, args.m_angularDamping);
+	}
+
+	if (args.m_restitution >= 0)
+	{
+		b3ChangeDynamicsInfoSetRestitution(command, bodyUniqueId, linkIndex, args.m_restitution);
+	}
+
+	if (args.m_contactStiffness >= 0 && args.m_contactDamping >= 0)
+	{
+		b3ChangeDynamicsInfoSetContactStiffnessAndDamping(command, bodyUniqueId, linkIndex, args.m_contactStiffness, args.m_contactDamping);
+	}
+
+	if (args.m_frictionAnchor >= 0)
+	{
+		b3ChangeDynamicsInfoSetFrictionAnchor(command, bodyUniqueId, linkIndex, args.m_frictionAnchor);
+	}
+	statusHandle = b3SubmitClientCommandAndWaitStatus(sm, command);
+	return true;
+}

--- a/upkie/cpp/actuation/RobotSimulator.cpp
+++ b/upkie/cpp/actuation/RobotSimulator.cpp
@@ -1,67 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Inria
+
 #include "RobotSimulator.h"
-#include <iostream>  // For error logging or debugging
+#include <iostream>
 
-bool RobotSimulatorClientAPI::changeDynamics(int bodyUniqueId, int linkIndex, struct RobotSimulatorChangeDynamicsArgs& args)
-{
-	b3PhysicsClientHandle sm = m_data->m_physicsClientHandle;
-	if (sm == 0)
-	{
-		b3Warning("Not connected to physics server.");
-		return false;
-	}
-	b3SharedMemoryCommandHandle command = b3InitChangeDynamicsInfo(sm);
-	b3SharedMemoryStatusHandle statusHandle;
+bool RobotSimulatorClientAPI::changeDynamics(
+  int bodyUniqueId,
+  int linkIndex,
+  struct RobotSimulatorChangeDynamicsArgs& args
+  ) {
+  b3PhysicsClientHandle sm = m_data->m_physicsClientHandle;
+  if (sm == 0) {
+  b3Warning("Not connected to physics server.");
+    return false;
+  }
+  b3SharedMemoryCommandHandle command = b3InitChangeDynamicsInfo(sm);
+  b3SharedMemoryStatusHandle statusHandle;
 
-	if (args.m_activationState >= 0)
-	{
-		b3ChangeDynamicsInfoSetActivationState(command, bodyUniqueId, args.m_activationState);
-	}
-	if (args.m_mass >= 0)
-	{
-		b3ChangeDynamicsInfoSetMass(command, bodyUniqueId, linkIndex, args.m_mass);
-	}
-    if (!(args.m_localInertiaDiagonal[0] == 0 && args.m_localInertiaDiagonal[1] == 0 && args.m_localInertiaDiagonal[2] == 0)) {
-        b3ChangeDynamicsInfoSetLocalInertiaDiagonal(command, bodyUniqueId, linkIndex, args.m_localInertiaDiagonal);
+  if (args.m_activationState >= 0) {
+    b3ChangeDynamicsInfoSetActivationState(
+    command,
+    bodyUniqueId,
+    args.m_activationState);
+  }
+  if (args.m_mass >= 0) {
+  b3ChangeDynamicsInfoSetMass(command, bodyUniqueId, linkIndex, args.m_mass);
+  }
+    if (!(args.m_localInertiaDiagonal[0] == 0
+  && args.m_localInertiaDiagonal[1] == 0
+  && args.m_localInertiaDiagonal[2] == 0)) {
+        b3ChangeDynamicsInfoSetLocalInertiaDiagonal(
+        command,
+        bodyUniqueId,
+        linkIndex,
+        args.m_localInertiaDiagonal);
     }
-	if (args.m_lateralFriction >= 0)
-	{
-		b3ChangeDynamicsInfoSetLateralFriction(command, bodyUniqueId, linkIndex, args.m_lateralFriction);
-	}
+  if (args.m_lateralFriction >= 0) {
+    b3ChangeDynamicsInfoSetLateralFriction(command,
+    bodyUniqueId,
+    linkIndex,
+    args.m_lateralFriction);
+  }
 
-	if (args.m_spinningFriction >= 0)
-	{
-		b3ChangeDynamicsInfoSetSpinningFriction(command, bodyUniqueId, linkIndex, args.m_spinningFriction);
-	}
+  if (args.m_spinningFriction >= 0) {
+    b3ChangeDynamicsInfoSetSpinningFriction(command,
+    bodyUniqueId,
+    linkIndex,
+    args.m_spinningFriction);
+  }
 
-	if (args.m_rollingFriction >= 0)
-	{
-		b3ChangeDynamicsInfoSetRollingFriction(command, bodyUniqueId, linkIndex, args.m_rollingFriction);
-	}
+  if (args.m_rollingFriction >= 0) {
+    b3ChangeDynamicsInfoSetRollingFriction(command,
+    bodyUniqueId,
+    linkIndex,
+    args.m_rollingFriction);
+  }
 
-	if (args.m_linearDamping >= 0)
-	{
-		b3ChangeDynamicsInfoSetLinearDamping(command, bodyUniqueId, args.m_linearDamping);
-	}
+  if (args.m_linearDamping >= 0) {
+    b3ChangeDynamicsInfoSetLinearDamping(command,
+    bodyUniqueId,
+    args.m_linearDamping);
+  }
 
-	if (args.m_angularDamping >= 0)
-	{
-		b3ChangeDynamicsInfoSetAngularDamping(command, bodyUniqueId, args.m_angularDamping);
-	}
+  if (args.m_angularDamping >= 0) {
+    b3ChangeDynamicsInfoSetAngularDamping(command,
+    bodyUniqueId,
+    args.m_angularDamping);
+  }
 
-	if (args.m_restitution >= 0)
-	{
-		b3ChangeDynamicsInfoSetRestitution(command, bodyUniqueId, linkIndex, args.m_restitution);
-	}
+  if (args.m_restitution >= 0) {
+    b3ChangeDynamicsInfoSetRestitution(command,
+    bodyUniqueId,
+    linkIndex,
+    args.m_restitution);
+  }
 
-	if (args.m_contactStiffness >= 0 && args.m_contactDamping >= 0)
-	{
-		b3ChangeDynamicsInfoSetContactStiffnessAndDamping(command, bodyUniqueId, linkIndex, args.m_contactStiffness, args.m_contactDamping);
-	}
+  if (args.m_contactStiffness >= 0 && args.m_contactDamping >= 0) {
+    b3ChangeDynamicsInfoSetContactStiffnessAndDamping(command,
+    bodyUniqueId,
+    linkIndex,
+    args.m_contactStiffness,
+    args.m_contactDamping);
+  }
 
-	if (args.m_frictionAnchor >= 0)
-	{
-		b3ChangeDynamicsInfoSetFrictionAnchor(command, bodyUniqueId, linkIndex, args.m_frictionAnchor);
-	}
-	statusHandle = b3SubmitClientCommandAndWaitStatus(sm, command);
-	return true;
+  if (args.m_frictionAnchor >= 0) {
+    b3ChangeDynamicsInfoSetFrictionAnchor(command,
+    bodyUniqueId,
+    linkIndex,
+    args.m_frictionAnchor);
+    }
+  statusHandle = b3SubmitClientCommandAndWaitStatus(sm, command);
+  return true;
 }

--- a/upkie/cpp/actuation/RobotSimulator.cpp
+++ b/upkie/cpp/actuation/RobotSimulator.cpp
@@ -1,94 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Inria
 
-#include "RobotSimulator.h"
+#include "upkie/cpp/actuation/RobotSimulator.h"
+
 #include <iostream>
 
 bool RobotSimulatorClientAPI::changeDynamics(
-  int bodyUniqueId,
-  int linkIndex,
-  struct RobotSimulatorChangeDynamicsArgs& args
-  ) {
+    int bodyUniqueId, int linkIndex,
+    struct RobotSimulatorChangeDynamicsArgs& args) {
   b3PhysicsClientHandle sm = m_data->m_physicsClientHandle;
   if (sm == 0) {
-  b3Warning("Not connected to physics server.");
+    b3Warning("Not connected to physics server.");
     return false;
   }
   b3SharedMemoryCommandHandle command = b3InitChangeDynamicsInfo(sm);
   b3SharedMemoryStatusHandle statusHandle;
 
   if (args.m_activationState >= 0) {
-    b3ChangeDynamicsInfoSetActivationState(
-    command,
-    bodyUniqueId,
-    args.m_activationState);
+    b3ChangeDynamicsInfoSetActivationState(command, bodyUniqueId,
+                                           args.m_activationState);
   }
   if (args.m_mass >= 0) {
-  b3ChangeDynamicsInfoSetMass(command, bodyUniqueId, linkIndex, args.m_mass);
+    b3ChangeDynamicsInfoSetMass(command, bodyUniqueId, linkIndex, args.m_mass);
   }
-    if (!(args.m_localInertiaDiagonal[0] == 0
-  && args.m_localInertiaDiagonal[1] == 0
-  && args.m_localInertiaDiagonal[2] == 0)) {
-        b3ChangeDynamicsInfoSetLocalInertiaDiagonal(
-        command,
-        bodyUniqueId,
-        linkIndex,
-        args.m_localInertiaDiagonal);
-    }
+  if (!(args.m_localInertiaDiagonal[0] == 0 &&
+        args.m_localInertiaDiagonal[1] == 0 &&
+        args.m_localInertiaDiagonal[2] == 0)) {
+    b3ChangeDynamicsInfoSetLocalInertiaDiagonal(
+        command, bodyUniqueId, linkIndex, args.m_localInertiaDiagonal);
+  }
   if (args.m_lateralFriction >= 0) {
-    b3ChangeDynamicsInfoSetLateralFriction(command,
-    bodyUniqueId,
-    linkIndex,
-    args.m_lateralFriction);
+    b3ChangeDynamicsInfoSetLateralFriction(command, bodyUniqueId, linkIndex,
+                                           args.m_lateralFriction);
   }
 
   if (args.m_spinningFriction >= 0) {
-    b3ChangeDynamicsInfoSetSpinningFriction(command,
-    bodyUniqueId,
-    linkIndex,
-    args.m_spinningFriction);
+    b3ChangeDynamicsInfoSetSpinningFriction(command, bodyUniqueId, linkIndex,
+                                            args.m_spinningFriction);
   }
 
   if (args.m_rollingFriction >= 0) {
-    b3ChangeDynamicsInfoSetRollingFriction(command,
-    bodyUniqueId,
-    linkIndex,
-    args.m_rollingFriction);
+    b3ChangeDynamicsInfoSetRollingFriction(command, bodyUniqueId, linkIndex,
+                                           args.m_rollingFriction);
   }
 
   if (args.m_linearDamping >= 0) {
-    b3ChangeDynamicsInfoSetLinearDamping(command,
-    bodyUniqueId,
-    args.m_linearDamping);
+    b3ChangeDynamicsInfoSetLinearDamping(command, bodyUniqueId,
+                                         args.m_linearDamping);
   }
 
   if (args.m_angularDamping >= 0) {
-    b3ChangeDynamicsInfoSetAngularDamping(command,
-    bodyUniqueId,
-    args.m_angularDamping);
+    b3ChangeDynamicsInfoSetAngularDamping(command, bodyUniqueId,
+                                          args.m_angularDamping);
   }
 
   if (args.m_restitution >= 0) {
-    b3ChangeDynamicsInfoSetRestitution(command,
-    bodyUniqueId,
-    linkIndex,
-    args.m_restitution);
+    b3ChangeDynamicsInfoSetRestitution(command, bodyUniqueId, linkIndex,
+                                       args.m_restitution);
   }
 
   if (args.m_contactStiffness >= 0 && args.m_contactDamping >= 0) {
-    b3ChangeDynamicsInfoSetContactStiffnessAndDamping(command,
-    bodyUniqueId,
-    linkIndex,
-    args.m_contactStiffness,
-    args.m_contactDamping);
+    b3ChangeDynamicsInfoSetContactStiffnessAndDamping(
+        command, bodyUniqueId, linkIndex, args.m_contactStiffness,
+        args.m_contactDamping);
   }
 
   if (args.m_frictionAnchor >= 0) {
-    b3ChangeDynamicsInfoSetFrictionAnchor(command,
-    bodyUniqueId,
-    linkIndex,
-    args.m_frictionAnchor);
-    }
+    b3ChangeDynamicsInfoSetFrictionAnchor(command, bodyUniqueId, linkIndex,
+                                          args.m_frictionAnchor);
+  }
   statusHandle = b3SubmitClientCommandAndWaitStatus(sm, command);
   return true;
 }

--- a/upkie/cpp/actuation/RobotSimulator.cpp
+++ b/upkie/cpp/actuation/RobotSimulator.cpp
@@ -16,56 +16,56 @@ bool RobotSimulatorClientAPI::changeDynamics(
   b3SharedMemoryCommandHandle command = b3InitChangeDynamicsInfo(sm);
   b3SharedMemoryStatusHandle statusHandle;
 
-  if (args.m_activationState >= 0) {
+  if (args.m_activationState >= 0.0) {
     b3ChangeDynamicsInfoSetActivationState(command, bodyUniqueId,
                                            args.m_activationState);
   }
-  if (args.m_mass >= 0) {
+  if (args.m_mass >= 0.0) {
     b3ChangeDynamicsInfoSetMass(command, bodyUniqueId, linkIndex, args.m_mass);
   }
-  if (!(args.m_localInertiaDiagonal[0] == 0 &&
-        args.m_localInertiaDiagonal[1] == 0 &&
-        args.m_localInertiaDiagonal[2] == 0)) {
+  if (!(std::abs(args.m_localInertiaDiagonal[0]) < 1e-6 &&
+        std::abs(args.m_localInertiaDiagonal[1]) < 1e-6 &&
+        std::abs(args.m_localInertiaDiagonal[2]) < 1e-6)) {
     b3ChangeDynamicsInfoSetLocalInertiaDiagonal(
         command, bodyUniqueId, linkIndex, args.m_localInertiaDiagonal);
   }
-  if (args.m_lateralFriction >= 0) {
+  if (args.m_lateralFriction >= 0.0) {
     b3ChangeDynamicsInfoSetLateralFriction(command, bodyUniqueId, linkIndex,
                                            args.m_lateralFriction);
   }
 
-  if (args.m_spinningFriction >= 0) {
+  if (args.m_spinningFriction >= 0.0) {
     b3ChangeDynamicsInfoSetSpinningFriction(command, bodyUniqueId, linkIndex,
                                             args.m_spinningFriction);
   }
 
-  if (args.m_rollingFriction >= 0) {
+  if (args.m_rollingFriction >= 0.0) {
     b3ChangeDynamicsInfoSetRollingFriction(command, bodyUniqueId, linkIndex,
                                            args.m_rollingFriction);
   }
 
-  if (args.m_linearDamping >= 0) {
+  if (args.m_linearDamping >= 0.0) {
     b3ChangeDynamicsInfoSetLinearDamping(command, bodyUniqueId,
                                          args.m_linearDamping);
   }
 
-  if (args.m_angularDamping >= 0) {
+  if (args.m_angularDamping >= 0.0) {
     b3ChangeDynamicsInfoSetAngularDamping(command, bodyUniqueId,
                                           args.m_angularDamping);
   }
 
-  if (args.m_restitution >= 0) {
+  if (args.m_restitution >= 0.0) {
     b3ChangeDynamicsInfoSetRestitution(command, bodyUniqueId, linkIndex,
                                        args.m_restitution);
   }
 
-  if (args.m_contactStiffness >= 0 && args.m_contactDamping >= 0) {
+  if (args.m_contactStiffness >= 0.0 && args.m_contactDamping >= 0.0) {
     b3ChangeDynamicsInfoSetContactStiffnessAndDamping(
         command, bodyUniqueId, linkIndex, args.m_contactStiffness,
         args.m_contactDamping);
   }
 
-  if (args.m_frictionAnchor >= 0) {
+  if (args.m_frictionAnchor >= 0.0) {
     b3ChangeDynamicsInfoSetFrictionAnchor(command, bodyUniqueId, linkIndex,
                                           args.m_frictionAnchor);
   }

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -13,6 +13,13 @@
 #include "SharedMemory/PhysicsClientC_API.h"
 #include "SharedMemory/b3RobotSimulatorClientAPI_InternalData.h"
 
+/*
+* Structure which contains the new link properties
+* 
+* This is a modification of b3RobotSimulatorChangeDynamicsArgs
+* with the addition of the attribute m_localInertiaDiagonal
+* to enable the modification of the inertia matrix of the link
+*/
 struct RobotSimulatorChangeDynamicsArgs {
   double m_mass;
   double m_lateralFriction;
@@ -43,6 +50,16 @@ struct RobotSimulatorChangeDynamicsArgs {
 };
 class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
  public:
+  /* Modifies the properties of a link
+  *
+  * This is a modification of the method changeDynamics of
+  * b3RobotSimulatorClientAPI to enable the modification of the inertia
+  * matrices.
+  * The usage is identical.
+  * \param[in] bodyUniqueId The body which links will be modified
+  * \param[in] linkIndex The link id
+  * \param[in] args Structure which contains the values to modify
+  */
   bool changeDynamics(int bodyUniqueId, int linkIndex,
                       RobotSimulatorChangeDynamicsArgs& args);
 };

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -15,7 +15,7 @@
 
 //! Structure which contains the new link properties
 struct RobotSimulatorChangeDynamicsArgs {
-  //! The mass of the robot link
+  //! The mass of the robot link (in kg)
   double m_mass;
   //! The friction in the lateral direction
   double m_lateralFriction;

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -58,7 +58,7 @@ struct RobotSimulatorChangeDynamicsArgs {
 //! Child class to enable modification of inertia matrices
 class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
  public:
-  /* Modifies the properties of a link
+  /*! Modifies the properties of a link
    *
    * This is a modification of the method changeDynamics of
    * b3RobotSimulatorClientAPI to enable the modification of the inertia

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -15,29 +15,29 @@
 
 //! Structure which contains the new link properties
 struct RobotSimulatorChangeDynamicsArgs {
-  // The mass of the robot link
+  //! The mass of the robot link
   double m_mass;
-  // The friction in the lateral direction
+  //! The friction in the lateral direction
   double m_lateralFriction;
-  // The friction during rotational motion
+  //! The friction during rotational motion
   double m_spinningFriction;
-  // The friction while rolling
+  //! The friction while rolling
   double m_rollingFriction;
-  // The coefficient of restitution
+  //! The coefficient of restitution
   double m_restitution;
-  // The damping factor for linear motion
+  //! The damping factor for linear motion
   double m_linearDamping;
-  // The damping factor for angular motion
+  //! The damping factor for angular motion
   double m_angularDamping;
-  // The stiffness of contact between objects
+  //! The stiffness of contact between objects
   double m_contactStiffness;
-  // The damping factor during collisions
+  //! The damping factor during collisions
   double m_contactDamping;
-  // Specifies whether friction is applied at a specific anchor point
+  //! Specifies whether friction is applied at a specific anchor point
   int m_frictionAnchor;
-  // The activation state of the link
+  //! The activation state of the link
   int m_activationState;
-  // The local inertia tensor diagonal components
+  //! The local inertia tensor diagonal components
   double m_localInertiaDiagonal[3];
 
   RobotSimulatorChangeDynamicsArgs()

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Inria
+
+#pragma once
+
 #ifndef ROBOT_SIMULATOR_CLIENT_API_H
 #define ROBOT_SIMULATOR_CLIENT_API_H
 
@@ -5,11 +10,10 @@
 #include "SharedMemory/PhysicsClientC_API.h"
 #include "SharedMemory/b3RobotSimulatorClientAPI_InternalData.h"
 #include "Bullet3Common/b3Logging.h"
-#include <Eigen/Dense>  // Make sure Eigen is included
+#include <Eigen/Dense>
 
 
-struct RobotSimulatorChangeDynamicsArgs
-{
+struct RobotSimulatorChangeDynamicsArgs{
     double m_mass;
     double m_lateralFriction;
     double m_spinningFriction;
@@ -37,12 +41,13 @@ struct RobotSimulatorChangeDynamicsArgs
           m_activationState(-1),
           m_localInertiaDiagonal{0, 0, 0}
         {
-        };
+        }
 };
 class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
-public:
-    // Override the changeDynamics method
-    bool changeDynamics(int bodyUniqueId, int linkIndex, RobotSimulatorChangeDynamicsArgs& args) ;
+ public:
+    bool changeDynamics(int bodyUniqueId,
+      int linkIndex,
+      RobotSimulatorChangeDynamicsArgs& args);
 };
 
 

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -6,49 +6,45 @@
 #ifndef ROBOT_SIMULATOR_CLIENT_API_H
 #define ROBOT_SIMULATOR_CLIENT_API_H
 
+#include <Eigen/Dense>
+
+#include "Bullet3Common/b3Logging.h"
 #include "RobotSimulator/b3RobotSimulatorClientAPI.h"
 #include "SharedMemory/PhysicsClientC_API.h"
 #include "SharedMemory/b3RobotSimulatorClientAPI_InternalData.h"
-#include "Bullet3Common/b3Logging.h"
-#include <Eigen/Dense>
 
+struct RobotSimulatorChangeDynamicsArgs {
+  double m_mass;
+  double m_lateralFriction;
+  double m_spinningFriction;
+  double m_rollingFriction;
+  double m_restitution;
+  double m_linearDamping;
+  double m_angularDamping;
+  double m_contactStiffness;
+  double m_contactDamping;
+  int m_frictionAnchor;
+  int m_activationState;
+  double m_localInertiaDiagonal[3];
 
-struct RobotSimulatorChangeDynamicsArgs{
-    double m_mass;
-    double m_lateralFriction;
-    double m_spinningFriction;
-    double m_rollingFriction;
-    double m_restitution;
-    double m_linearDamping;
-    double m_angularDamping;
-    double m_contactStiffness;
-    double m_contactDamping;
-    int m_frictionAnchor;
-    int m_activationState;
-    double m_localInertiaDiagonal[3];
-
-    RobotSimulatorChangeDynamicsArgs()
-        : m_mass(-1),
-          m_lateralFriction(-1),
-          m_spinningFriction(-1),
-          m_rollingFriction(-1),
-          m_restitution(-1),
-          m_linearDamping(-1),
-          m_angularDamping(-1),
-          m_contactStiffness(-1),
-          m_contactDamping(-1),
-          m_frictionAnchor(-1),
-          m_activationState(-1),
-          m_localInertiaDiagonal{0, 0, 0}
-        {
-        }
+  RobotSimulatorChangeDynamicsArgs()
+      : m_mass(-1),
+        m_lateralFriction(-1),
+        m_spinningFriction(-1),
+        m_rollingFriction(-1),
+        m_restitution(-1),
+        m_linearDamping(-1),
+        m_angularDamping(-1),
+        m_contactStiffness(-1),
+        m_contactDamping(-1),
+        m_frictionAnchor(-1),
+        m_activationState(-1),
+        m_localInertiaDiagonal{0, 0, 0} {}
 };
 class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
  public:
-    bool changeDynamics(int bodyUniqueId,
-      int linkIndex,
-      RobotSimulatorChangeDynamicsArgs& args);
+  bool changeDynamics(int bodyUniqueId, int linkIndex,
+                      RobotSimulatorChangeDynamicsArgs& args);
 };
-
 
 #endif  // ROBOT_SIMULATOR_CLIENT_API_H

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -13,13 +13,7 @@
 #include "SharedMemory/PhysicsClientC_API.h"
 #include "SharedMemory/b3RobotSimulatorClientAPI_InternalData.h"
 
-/*
- * Structure which contains the new link properties
- *
- * This is a modification of b3RobotSimulatorChangeDynamicsArgs
- * with the addition of the attribute m_localInertiaDiagonal
- * to enable the modification of the inertia matrix of the link
- */
+//! Structure which contains the new link properties
 struct RobotSimulatorChangeDynamicsArgs {
   double m_mass;
   double m_lateralFriction;
@@ -48,6 +42,8 @@ struct RobotSimulatorChangeDynamicsArgs {
         m_activationState(-1),
         m_localInertiaDiagonal{0, 0, 0} {}
 };
+
+//! Child class to enable modification of inertia matrices
 class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
  public:
   /* Modifies the properties of a link

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -14,12 +14,12 @@
 #include "SharedMemory/b3RobotSimulatorClientAPI_InternalData.h"
 
 /*
-* Structure which contains the new link properties
-* 
-* This is a modification of b3RobotSimulatorChangeDynamicsArgs
-* with the addition of the attribute m_localInertiaDiagonal
-* to enable the modification of the inertia matrix of the link
-*/
+ * Structure which contains the new link properties
+ *
+ * This is a modification of b3RobotSimulatorChangeDynamicsArgs
+ * with the addition of the attribute m_localInertiaDiagonal
+ * to enable the modification of the inertia matrix of the link
+ */
 struct RobotSimulatorChangeDynamicsArgs {
   double m_mass;
   double m_lateralFriction;
@@ -51,15 +51,15 @@ struct RobotSimulatorChangeDynamicsArgs {
 class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
  public:
   /* Modifies the properties of a link
-  *
-  * This is a modification of the method changeDynamics of
-  * b3RobotSimulatorClientAPI to enable the modification of the inertia
-  * matrices.
-  * The usage is identical.
-  * \param[in] bodyUniqueId The body which links will be modified
-  * \param[in] linkIndex The link id
-  * \param[in] args Structure which contains the values to modify
-  */
+   *
+   * This is a modification of the method changeDynamics of
+   * b3RobotSimulatorClientAPI to enable the modification of the inertia
+   * matrices.
+   * The usage is identical.
+   * \param[in] bodyUniqueId The body which links will be modified
+   * \param[in] linkIndex The link id
+   * \param[in] args Structure which contains the values to modify
+   */
   bool changeDynamics(int bodyUniqueId, int linkIndex,
                       RobotSimulatorChangeDynamicsArgs& args);
 };

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -15,17 +15,29 @@
 
 //! Structure which contains the new link properties
 struct RobotSimulatorChangeDynamicsArgs {
+  // The mass of the robot link
   double m_mass;
+  // The friction in the lateral direction
   double m_lateralFriction;
+  // The friction during rotational motion
   double m_spinningFriction;
+  // The friction while rolling
   double m_rollingFriction;
+  // The coefficient of restitution
   double m_restitution;
+  // The damping factor for linear motion
   double m_linearDamping;
+  // The damping factor for angular motion
   double m_angularDamping;
+  // The stiffness of contact between objects
   double m_contactStiffness;
+  // The damping factor during collisions
   double m_contactDamping;
+  // Specifies whether friction is applied at a specific anchor point
   int m_frictionAnchor;
+  // The activation state of the link
   int m_activationState;
+  // The local inertia tensor diagonal components
   double m_localInertiaDiagonal[3];
 
   RobotSimulatorChangeDynamicsArgs()

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -21,7 +21,7 @@ struct RobotSimulatorChangeDynamicsArgs
     double m_contactDamping;
     int m_frictionAnchor;
     int m_activationState;
-    const double m_localInertiaDiagonal[3];
+    double m_localInertiaDiagonal[3];
 
     RobotSimulatorChangeDynamicsArgs()
         : m_mass(-1),

--- a/upkie/cpp/actuation/RobotSimulator.h
+++ b/upkie/cpp/actuation/RobotSimulator.h
@@ -1,0 +1,49 @@
+#ifndef ROBOT_SIMULATOR_CLIENT_API_H
+#define ROBOT_SIMULATOR_CLIENT_API_H
+
+#include "RobotSimulator/b3RobotSimulatorClientAPI.h"
+#include "SharedMemory/PhysicsClientC_API.h"
+#include "SharedMemory/b3RobotSimulatorClientAPI_InternalData.h"
+#include "Bullet3Common/b3Logging.h"
+#include <Eigen/Dense>  // Make sure Eigen is included
+
+
+struct RobotSimulatorChangeDynamicsArgs
+{
+    double m_mass;
+    double m_lateralFriction;
+    double m_spinningFriction;
+    double m_rollingFriction;
+    double m_restitution;
+    double m_linearDamping;
+    double m_angularDamping;
+    double m_contactStiffness;
+    double m_contactDamping;
+    int m_frictionAnchor;
+    int m_activationState;
+    const double m_localInertiaDiagonal[3];
+
+    RobotSimulatorChangeDynamicsArgs()
+        : m_mass(-1),
+          m_lateralFriction(-1),
+          m_spinningFriction(-1),
+          m_rollingFriction(-1),
+          m_restitution(-1),
+          m_linearDamping(-1),
+          m_angularDamping(-1),
+          m_contactStiffness(-1),
+          m_contactDamping(-1),
+          m_frictionAnchor(-1),
+          m_activationState(-1),
+          m_localInertiaDiagonal{0, 0, 0}
+        {
+        };
+};
+class RobotSimulatorClientAPI : public b3RobotSimulatorClientAPI {
+public:
+    // Override the changeDynamics method
+    bool changeDynamics(int bodyUniqueId, int linkIndex, RobotSimulatorChangeDynamicsArgs& args) ;
+};
+
+
+#endif  // ROBOT_SIMULATOR_CLIENT_API_H

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -245,10 +245,10 @@ TEST_F(BulletInterfaceTest, MassRandomizationIsDifferent) {
   interface_->get_nominal_masses();
   const std::map<int, double> randomized_masses = interface_->nominal_masses;
   for (const auto& [id, nominal_mass] : nominal_masses) {
-        double randomized_mass = randomized_masses.at(id);
-        ASSERT_NE(nominal_mass, randomized_mass);
-        ASSERT_LT(randomized_mass, 1.1 * nominal_mass);
-        ASSERT_GT(randomized_mass, 0.9 * nominal_mass);
+    double randomized_mass = randomized_masses.at(id);
+    ASSERT_NE(nominal_mass, randomized_mass);
+    ASSERT_LT(randomized_mass, 1.1 * nominal_mass);
+    ASSERT_GT(randomized_mass, 0.9 * nominal_mass);
   }
   interface_->mass_randomization_epsilon_ = 0.0;
 }

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -237,6 +237,17 @@ TEST_F(BulletInterfaceTest, JointRepliesHaveVoltage) {
   }
 }
 
+TEST_F(BulletInterfaceTest, MassRandomizationIsDifferent) {
+  interface_.get_nominal_masses();
+  const double nominal_mass = interface_.nominal_masses();
+  interface_.mass_randomization_epsilon_ = 0.1;
+  interface_.reset();
+  const double randomized_mass = interface
+  ASSERT_NE(nominal_mass, randomized_mass);
+  ASSERT_LT(randomized_mass, 1.1 * nominal_mass);
+  ASSERT_GT(randomized_mass, 0.9 * nominal_mass);
+}
+
 TEST_F(BulletInterfaceTest, ObserveImuOrientation) {
   Eigen::Quaterniond orientation_base_in_world = {0., 1., 0., 0.};
 

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -238,14 +238,19 @@ TEST_F(BulletInterfaceTest, JointRepliesHaveVoltage) {
 }
 
 TEST_F(BulletInterfaceTest, MassRandomizationIsDifferent) {
-  interface_.get_nominal_masses();
-  const double nominal_mass = interface_.nominal_masses();
-  interface_.mass_randomization_epsilon_ = 0.1;
-  interface_.reset();
-  const double randomized_mass = interface
-  ASSERT_NE(nominal_mass, randomized_mass);
-  ASSERT_LT(randomized_mass, 1.1 * nominal_mass);
-  ASSERT_GT(randomized_mass, 0.9 * nominal_mass);
+  interface_->get_nominal_masses();
+  const std::map<int, double> nominal_masses = interface_->nominal_masses;
+  interface_->mass_randomization_epsilon_ = 0.1;
+  interface_->randomize_masses();
+  interface_->get_nominal_masses();
+  const std::map<int, double> randomized_masses = interface_->nominal_masses;
+  for (const auto& [id, nominal_mass] : nominal_masses) {
+        double randomized_mass = randomized_masses.at(id);
+        ASSERT_NE(nominal_mass, randomized_mass);
+        ASSERT_LT(randomized_mass, 1.1 * nominal_mass);
+        ASSERT_GT(randomized_mass, 0.9 * nominal_mass);
+  }
+  interface_->mass_randomization_epsilon_ = 0.0;
 }
 
 TEST_F(BulletInterfaceTest, ObserveImuOrientation) {

--- a/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
+++ b/upkie/cpp/actuation/tests/BulletInterfaceTest.cpp
@@ -238,11 +238,11 @@ TEST_F(BulletInterfaceTest, JointRepliesHaveVoltage) {
 }
 
 TEST_F(BulletInterfaceTest, MassRandomizationIsDifferent) {
-  interface_->get_nominal_masses();
+  interface_->save_nominal_masses();
   const std::map<int, double> nominal_masses = interface_->nominal_masses;
-  interface_->mass_randomization_epsilon_ = 0.1;
+  interface_->inertia_randomization_ = 0.1;
   interface_->randomize_masses();
-  interface_->get_nominal_masses();
+  interface_->save_nominal_masses();
   const std::map<int, double> randomized_masses = interface_->nominal_masses;
   for (const auto& [id, nominal_mass] : nominal_masses) {
     double randomized_mass = randomized_masses.at(id);
@@ -250,7 +250,7 @@ TEST_F(BulletInterfaceTest, MassRandomizationIsDifferent) {
     ASSERT_LT(randomized_mass, 1.1 * nominal_mass);
     ASSERT_GT(randomized_mass, 0.9 * nominal_mass);
   }
-  interface_->mass_randomization_epsilon_ = 0.0;
+  interface_->inertia_randomization_ = 0.0;
 }
 
 TEST_F(BulletInterfaceTest, ObserveImuOrientation) {


### PR DESCRIPTION
Hi !

This PR adds the argument `mass-randomization-epsilon` to the bullet spine.
When it is not 0, at reset, it randomizes the masses of the links uniformly around the nominal values.
$` \text{Randomized mass} = \text{Nominal mass} \cdot u, \quad u \sim \mathcal{U}(1 - \epsilon, 1 + \epsilon) `$

Cheers! 