### PR TITLE
env: Remove `leg_return_period` from ground-velocity env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- env: Remove unused `leg_return_period` and hard-code it to one second
 - model: Remove C++ `upkie::model` namespace
 - observers: Remove upper-leg and wheel joints from configurable parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - env: Remove unused `leg_return_period` and hard-code it to one second
+- env: Replace contingent `parse_first_observation` by a reset override
 - model: Remove C++ `upkie::model` namespace
 - observers: Remove upper-leg and wheel joints from configurable parameters
 

--- a/upkie/envs/tests/upkie_base_env_test.py
+++ b/upkie/envs/tests/upkie_base_env_test.py
@@ -32,9 +32,6 @@ class UpkieTestEnv(UpkieBaseEnv):
             dtype=np.float32,
         )
 
-    def parse_first_observation(self, spine_observation: dict) -> None:
-        pass
-
     def get_env_observation(self, spine_observation: dict) -> np.ndarray:
         return np.full((1,), 0.5, dtype=self.observation_space.dtype)
 

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -186,7 +186,6 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
         self.__reset_rate()
         self.__reset_init_state()
         spine_observation = self._spine.start(self._spine_config)
-        self.parse_first_observation(spine_observation)
         observation = self.get_env_observation(spine_observation)
         info = {"spine_observation": spine_observation}
         return observation, info
@@ -262,7 +261,7 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
         observation = self.get_env_observation(spine_observation)
         reward = self.get_reward(observation, action)
         terminated = self.detect_fall(spine_observation)
-        truncated = False
+        truncated = False  # rather handled by e.g. a TimeLimit wrapper
         info = {"spine_observation": spine_observation}
         return observation, reward, terminated, truncated, info
 
@@ -285,16 +284,6 @@ class UpkieBaseEnv(abc.ABC, gymnasium.Env):
             )
             return True
         return False
-
-    def parse_first_observation(self, spine_observation: dict) -> None:
-        r"""!
-        Parse first observation after the spine interface is initialized.
-
-        \param spine_observation First observation.
-
-        This method is an optional way for environments to record some state
-        (abstracted away from the agnet) at reset.
-        """
 
     @abc.abstractmethod
     def get_env_observation(self, spine_observation: dict):

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -261,7 +261,7 @@ class UpkieBaseEnv(abc.ABC, gym.Env):
         observation = self.get_env_observation(spine_observation)
         reward = self.get_reward(observation, action)
         terminated = self.detect_fall(spine_observation)
-        truncated = False  # rather handled by e.g. a TimeLimit wrapper
+        truncated = False  # will be handled by e.g. a TimeLimit wrapper
         info = {"spine_observation": spine_observation}
         return observation, reward, terminated, truncated, info
 

--- a/upkie/envs/upkie_base_env.py
+++ b/upkie/envs/upkie_base_env.py
@@ -7,7 +7,7 @@
 import abc
 from typing import Any, Optional, Tuple
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 import upkie_description
 from loop_rate_limiters import RateLimiter
@@ -21,7 +21,7 @@ from upkie.utils.robot_state import RobotState
 from upkie.utils.spdlog import logging
 
 
-class UpkieBaseEnv(abc.ABC, gymnasium.Env):
+class UpkieBaseEnv(abc.ABC, gym.Env):
     r"""!
     Base class for Upkie environments.
 

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -33,8 +33,8 @@ class UpkieGroundVelocity(UpkieBaseEnv):
     instance by the [MPC balancer](https://github.com/upkie/mpc_balancer/) and
     [PPO balancer](https://github.com/upkie/ppo_balancer) agents.
 
-    \note For reinforcement learning with neural networks: the observation
-    space and action space are not normalized.
+    \note For reinforcement learning with neural-network policies: the
+    observation space and action space are not normalized.
 
     ### Action space
 
@@ -80,11 +80,6 @@ class UpkieGroundVelocity(UpkieBaseEnv):
     ## Action space.
     action_space: spaces.box.Box
 
-    ## \var leg_return_period
-    ## Time constant for the legs (hips and knees) to revert to their neutral
-    ## configuration.
-    leg_return_period: float
-
     ## \var left_wheeled
     ## Set to True (default) if the robot is left wheeled, that is, a positive
     ## turn of the left wheel results in forward motion. Set to False for a
@@ -113,7 +108,6 @@ class UpkieGroundVelocity(UpkieBaseEnv):
         frequency: float = 200.0,
         frequency_checks: bool = True,
         init_state: Optional[RobotState] = None,
-        leg_return_period: float = 1.0,
         left_wheeled: bool = True,
         max_ground_velocity: float = 1.0,
         regulate_frequency: bool = True,
@@ -132,12 +126,11 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             control loop runs slower than the desired `frequency`. Set this
             parameter to false to disable these warnings.
         \param init_state Initial state of the robot, only used in simulation.
-        \param leg_return_period Time constant for the legs (hips and knees) to
-            revert to their neutral configuration.
         \param left_wheeled Set to True (default) if the robot is left wheeled,
             that is, a positive turn of the left wheel results in forward
             motion. Set to False for a right-wheeled variant.
         \param max_ground_velocity Maximum commanded ground velocity in m/s.
+            The default value of 1 m/s is conservative, don't hesitate
         \param regulate_frequency Enables loop frequency regulation.
         \param reward Reward function of the environment.
         \param shm_name Name of shared-memory file.
@@ -201,7 +194,6 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             for joint in self.model.upper_leg_joints
         }
 
-        self.leg_return_period = leg_return_period
         self.left_wheeled = left_wheeled
         self.reward = reward
         self.wheel_radius = wheel_radius
@@ -266,8 +258,8 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             prev_position = self.__leg_servo_action[joint.name]["position"]
             new_position = low_pass_filter(
                 prev_output=prev_position,
-                cutoff_period=self.leg_return_period,
-                new_input=0.0,
+                new_input=0.0,  # go to neutral configuration
+                cutoff_period=1.0,  # in roughly one second
                 dt=self.dt,
             )
             self.__leg_servo_action[joint.name]["position"] = new_position

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -130,7 +130,8 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             that is, a positive turn of the left wheel results in forward
             motion. Set to False for a right-wheeled variant.
         \param max_ground_velocity Maximum commanded ground velocity in m/s.
-            The default value of 1 m/s is conservative, don't hesitate
+            The default value of 1 m/s is conservative, don't hesitate to
+            increase it once you feel confident in your agent.
         \param regulate_frequency Enables loop frequency regulation.
         \param reward Reward function of the environment.
         \param shm_name Name of shared-memory file.

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -216,17 +216,12 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             - `info`: Dictionary with auxiliary diagnostic information. For
               Upkie this is the full observation dictionary sent by the spine.
         """
-        return super().reset(seed=seed)
-
-    def parse_first_observation(self, spine_observation: dict) -> None:
-        r"""!
-        Parse first observation after the spine interface is initialized.
-
-        \param spine_observation First observation.
-        """
+        observation, info = super().reset(seed=seed, options=options)
+        spine_observation = info["spine_observation"]
         for joint in self.model.upper_leg_joints:
             position = spine_observation["servo"][joint.name]["position"]
             self.__leg_servo_action[joint.name]["position"] = position
+        return observation, info
 
     def get_env_observation(self, spine_observation: dict) -> np.ndarray:
         r"""!

--- a/upkie/envs/upkie_ground_velocity.py
+++ b/upkie/envs/upkie_ground_velocity.py
@@ -8,8 +8,8 @@
 import math
 from typing import Dict, Optional, Tuple
 
+import gymnasium as gym
 import numpy as np
-from gymnasium import spaces
 
 from upkie.exceptions import UpkieException
 from upkie.utils.clamp import clamp_and_warn
@@ -78,7 +78,7 @@ class UpkieGroundVelocity(UpkieBaseEnv):
 
     ## \var action_space
     ## Action space.
-    action_space: spaces.box.Box
+    action_space: gym.spaces.Box
 
     ## \var left_wheeled
     ## Set to True (default) if the robot is left wheeled, that is, a positive
@@ -88,7 +88,7 @@ class UpkieGroundVelocity(UpkieBaseEnv):
 
     ## \var observation_space
     ## Observation space.
-    observation_space: spaces.box.Box
+    observation_space: gym.spaces.Box
 
     ## \var reward
     ## Reward function of the environment.
@@ -169,7 +169,7 @@ class UpkieGroundVelocity(UpkieBaseEnv):
             ],
             dtype=float,
         )
-        self.observation_space = spaces.Box(
+        self.observation_space = gym.spaces.Box(
             -observation_limit,
             +observation_limit,
             shape=observation_limit.shape,
@@ -178,7 +178,7 @@ class UpkieGroundVelocity(UpkieBaseEnv):
 
         # gymnasium.Env: action_space
         action_limit = np.array([max_ground_velocity], dtype=float)
-        self.action_space = spaces.Box(
+        self.action_space = gym.spaces.Box(
             -action_limit,
             +action_limit,
             shape=action_limit.shape,

--- a/upkie/envs/upkie_servo_positions.py
+++ b/upkie/envs/upkie_servo_positions.py
@@ -6,7 +6,7 @@
 
 from typing import Optional, Set
 
-from gymnasium import spaces
+import gymnasium as gym
 
 from upkie.utils.robot_state import RobotState
 
@@ -49,7 +49,7 @@ class UpkieServoPositions(UpkieServos):
 
     ## \var action_space
     ## Action space.
-    action_space: spaces.dict.Dict
+    action_space: gym.spaces.dict.Dict
 
     def __init__(
         self,
@@ -87,21 +87,21 @@ class UpkieServoPositions(UpkieServos):
             spine_config=spine_config,
         )
         action_space = {
-            joint.name: spaces.Dict(
+            joint.name: gym.spaces.Dict(
                 {
-                    "position": spaces.Box(
+                    "position": gym.spaces.Box(
                         low=joint.limit.lower,
                         high=joint.limit.upper,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "kp_scale": spaces.Box(
+                    "kp_scale": gym.spaces.Box(
                         low=0.0,
                         high=1.0,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "kd_scale": spaces.Box(
+                    "kd_scale": gym.spaces.Box(
                         low=0.0,
                         high=1.0,
                         shape=(1,),
@@ -111,4 +111,4 @@ class UpkieServoPositions(UpkieServos):
             )
             for joint in self.model.joints
         }
-        self.action_space = spaces.Dict(action_space)
+        self.action_space = gym.spaces.Dict(action_space)

--- a/upkie/envs/upkie_servos.py
+++ b/upkie/envs/upkie_servos.py
@@ -6,8 +6,8 @@
 
 from typing import Optional, Set, Tuple
 
+import gymnasium as gym
 import numpy as np
-from gymnasium import spaces
 
 from upkie.utils.clamp import clamp_and_warn
 from upkie.utils.robot_state import RobotState
@@ -104,11 +104,11 @@ class UpkieServos(UpkieBaseEnv):
 
     ## \var action_space
     ## Action space.
-    action_space: spaces.dict.Dict
+    action_space: gym.spaces.dict.Dict
 
     ## \var observation_space
     ## Observation space.
-    observation_space: spaces.dict.Dict
+    observation_space: gym.spaces.dict.Dict
 
     ## \var version
     ## Environment version number.
@@ -157,39 +157,39 @@ class UpkieServos(UpkieBaseEnv):
         servo_space = {}
 
         for joint in self.model.joints:
-            action_space[joint.name] = spaces.Dict(
+            action_space[joint.name] = gym.spaces.Dict(
                 {
-                    "position": spaces.Box(
+                    "position": gym.spaces.Box(
                         low=joint.limit.lower,
                         high=joint.limit.upper,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "velocity": spaces.Box(
+                    "velocity": gym.spaces.Box(
                         low=-joint.limit.velocity,
                         high=+joint.limit.velocity,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "feedforward_torque": spaces.Box(
+                    "feedforward_torque": gym.spaces.Box(
                         low=-joint.limit.effort,
                         high=+joint.limit.effort,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "kp_scale": spaces.Box(
+                    "kp_scale": gym.spaces.Box(
                         low=0.0,
                         high=1.0,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "kd_scale": spaces.Box(
+                    "kd_scale": gym.spaces.Box(
                         low=0.0,
                         high=1.0,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "maximum_torque": spaces.Box(
+                    "maximum_torque": gym.spaces.Box(
                         low=0.0,
                         high=joint.limit.effort,
                         shape=(1,),
@@ -197,33 +197,33 @@ class UpkieServos(UpkieBaseEnv):
                     ),
                 }
             )
-            servo_space[joint.name] = spaces.Dict(
+            servo_space[joint.name] = gym.spaces.Dict(
                 {
-                    "position": spaces.Box(
+                    "position": gym.spaces.Box(
                         low=joint.limit.lower,
                         high=joint.limit.upper,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "velocity": spaces.Box(
+                    "velocity": gym.spaces.Box(
                         low=-joint.limit.velocity,
                         high=+joint.limit.velocity,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "torque": spaces.Box(
+                    "torque": gym.spaces.Box(
                         low=-joint.limit.effort,
                         high=+joint.limit.effort,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "temperature": spaces.Box(
+                    "temperature": gym.spaces.Box(
                         low=0.0,
                         high=100.0,
                         shape=(1,),
                         dtype=float,
                     ),
-                    "voltage": spaces.Box(
+                    "voltage": gym.spaces.Box(
                         low=10.0,  # moteus min 10 V
                         high=44.0,  # moteus max 44 V
                         shape=(1,),
@@ -257,10 +257,10 @@ class UpkieServos(UpkieBaseEnv):
             }
 
         # gymnasium.Env: action_space
-        self.action_space = spaces.Dict(action_space)
+        self.action_space = gym.spaces.Dict(action_space)
 
         # gymnasium.Env: observation_space
-        self.observation_space = spaces.Dict(servo_space)
+        self.observation_space = gym.spaces.Dict(servo_space)
 
         # Class attributes
         self.__neutral_action = neutral_action

--- a/upkie/envs/wheeled_inverted_pendulum.py
+++ b/upkie/envs/wheeled_inverted_pendulum.py
@@ -8,10 +8,9 @@
 
 from typing import Any, Optional, Tuple, Union
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 import upkie_description
-from gymnasium import spaces
 from loop_rate_limiters import RateLimiter
 from numpy import cos, sin
 
@@ -25,7 +24,7 @@ from .rewards import WheeledInvertedPendulumReward
 GRAVITY: float = 9.81  # [m] / [s]²
 
 
-class WheeledInvertedPendulum(gymnasium.Env):
+class WheeledInvertedPendulum(gym.Env):
     r"""!
     Wheeled inverted pendulum model.
 
@@ -84,7 +83,7 @@ class WheeledInvertedPendulum(gymnasium.Env):
 
     ## \var action_space
     ## Action space.
-    action_space: spaces.box.Box
+    action_space: gym.spaces.Box
 
     ## \var dt
     ## Period of the control loop in seconds.
@@ -108,7 +107,7 @@ class WheeledInvertedPendulum(gymnasium.Env):
 
     ## \var observation_space
     ## Observation space.
-    observation_space: spaces.box.Box
+    observation_space: gym.spaces.Box
 
     ## \var plot
     ## Optional plot used for rendering.
@@ -244,7 +243,7 @@ class WheeledInvertedPendulum(gymnasium.Env):
             ],
             dtype=float,
         )
-        self.observation_space = spaces.Box(
+        self.observation_space = gym.spaces.Box(
             -observation_limit,
             +observation_limit,
             shape=observation_limit.shape,
@@ -253,7 +252,7 @@ class WheeledInvertedPendulum(gymnasium.Env):
 
         # gymnasium.Env: action_space
         action_limit = np.array([max_ground_velocity], dtype=float)
-        self.action_space = spaces.Box(
+        self.action_space = gym.spaces.Box(
             -action_limit,
             +action_limit,
             shape=action_limit.shape,

--- a/upkie/envs/wrappers/add_action_to_observation.py
+++ b/upkie/envs/wrappers/add_action_to_observation.py
@@ -4,14 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 Inria
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
-from gymnasium import spaces
 
 from upkie.exceptions import UpkieException
 
 
-class AddActionToObservation(gymnasium.ObservationWrapper):
+class AddActionToObservation(gym.ObservationWrapper):
     """!
     Append last action vector to the observation vector.
 
@@ -22,7 +21,7 @@ class AddActionToObservation(gymnasium.ObservationWrapper):
 
     ## @var observation_space
     ## Observation space.
-    observation_space: spaces.box.Box
+    observation_space: gym.spaces.Box
 
     _last_action: np.ndarray
 
@@ -42,7 +41,7 @@ class AddActionToObservation(gymnasium.ObservationWrapper):
                 f"and {env.action_space.dtype=}"
             )
         low = np.concatenate([env.observation_space.low, env.action_space.low])
-        self.observation_space = spaces.Box(
+        self.observation_space = gym.spaces.Box(
             low=low,
             high=np.concatenate(
                 [env.observation_space.high, env.action_space.high]

--- a/upkie/envs/wrappers/add_lag_to_action.py
+++ b/upkie/envs/wrappers/add_lag_to_action.py
@@ -6,14 +6,13 @@
 
 from typing import Tuple, Union
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
-from gymnasium.spaces import Box
 
 from upkie.utils.filters import low_pass_filter
 
 
-class AddLagToAction(gymnasium.Wrapper):
+class AddLagToAction(gym.Wrapper):
     """!
     Model lag by applying a low-pass filter to the action of an environment.
 
@@ -41,9 +40,9 @@ class AddLagToAction(gymnasium.Wrapper):
     ## \var time_constant_box
     ## Box space from which the time constant is sampled at every reset of the
     ## environment.
-    time_constant_box: Box
+    time_constant_box: gym.spaces.Box
 
-    def __init__(self, env, time_constant: Union[float, Box]):
+    def __init__(self, env, time_constant: Union[float, gym.spaces.Box]):
         r"""!
         Initialize wrapper.
 
@@ -57,8 +56,10 @@ class AddLagToAction(gymnasium.Wrapper):
         super().__init__(env)
         time_constant_box = (
             time_constant
-            if isinstance(time_constant, Box)
-            else Box(low=time_constant - 1e-10, high=time_constant + 1e-10)
+            if isinstance(time_constant, gym.spaces.Box)
+            else gym.spaces.Box(
+                low=time_constant - 1e-10, high=time_constant + 1e-10
+            )
         )
         self.filtered_action = np.zeros(env.action_space.shape)
         self.time_constant = time_constant_box.sample()

--- a/upkie/envs/wrappers/differentiate_action.py
+++ b/upkie/envs/wrappers/differentiate_action.py
@@ -6,12 +6,11 @@
 
 from typing import Tuple
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
-from gymnasium import spaces
 
 
-class DifferentiateAction(gymnasium.Wrapper):
+class DifferentiateAction(gym.Wrapper):
     r"""!
     Act on the derivative of the action.
     """
@@ -23,7 +22,7 @@ class DifferentiateAction(gymnasium.Wrapper):
 
     ## @var action_space
     ## Action space.
-    action_space: spaces.box.Box
+    action_space: gym.spaces.Box
 
     def __init__(
         self,
@@ -46,7 +45,7 @@ class DifferentiateAction(gymnasium.Wrapper):
         \note We assume the original action lives in a vector space.
         """
         super().__init__(env)
-        self.action_space = spaces.Box(
+        self.action_space = gym.spaces.Box(
             np.float32(min_derivative),
             np.float32(max_derivative),
             shape=env.action_space.shape,

--- a/upkie/envs/wrappers/noisify_action.py
+++ b/upkie/envs/wrappers/noisify_action.py
@@ -6,13 +6,13 @@
 
 """Add noise to the action of an environment."""
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.exceptions import UpkieException
 
 
-class NoisifyAction(gymnasium.ActionWrapper):
+class NoisifyAction(gym.ActionWrapper):
     """!
     Add noise to the action of an environment.
     """

--- a/upkie/envs/wrappers/noisify_observation.py
+++ b/upkie/envs/wrappers/noisify_observation.py
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 Inria
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.exceptions import UpkieException
 
 
-class NoisifyObservation(gymnasium.ObservationWrapper):
+class NoisifyObservation(gym.ObservationWrapper):
     """!
     Add noise to the observation of an environment.
     """

--- a/upkie/envs/wrappers/tests/add_action_to_observation_test.py
+++ b/upkie/envs/wrappers/tests/add_action_to_observation_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.envs.wrappers.add_action_to_observation import (
@@ -30,7 +30,7 @@ class AddActionToObservationTestCase(unittest.TestCase):
         try:
             from stable_baselines3.common.env_checker import check_env
 
-            env = gymnasium.make("Pendulum-v1")
+            env = gym.make("Pendulum-v1")
             wrapped_env = AddActionToObservation(env)
             check_env(wrapped_env)
         except ImportError:

--- a/upkie/envs/wrappers/tests/add_lag_to_action_test.py
+++ b/upkie/envs/wrappers/tests/add_lag_to_action_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.envs.wrappers.add_lag_to_action import AddLagToAction
@@ -27,7 +27,7 @@ class AddLagToActionTestCase(unittest.TestCase):
         try:
             from stable_baselines3.common.env_checker import check_env
 
-            env = gymnasium.make("Pendulum-v1")
+            env = gym.make("Pendulum-v1")
             lpf_env = AddLagToAction(env, time_constant=1.0)
             check_env(lpf_env)
         except ImportError:

--- a/upkie/envs/wrappers/tests/differentiate_action_test.py
+++ b/upkie/envs/wrappers/tests/differentiate_action_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.envs.wrappers.differentiate_action import DifferentiateAction
@@ -31,7 +31,7 @@ class DifferentiateActionTestCase(unittest.TestCase):
         try:
             from stable_baselines3.common.env_checker import check_env
 
-            env = gymnasium.make("Pendulum-v1")
+            env = gym.make("Pendulum-v1")
             diff_env = DifferentiateAction(
                 env,
                 min_derivative=-0.1,

--- a/upkie/envs/wrappers/tests/envs.py
+++ b/upkie/envs/wrappers/tests/envs.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 Inria
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
 
-class ActionObserverEnv(gymnasium.Env):
+class ActionObserverEnv(gym.Env):
     def __init__(self):
         action_space = spaces.Box(0.0, 2.0, shape=(1,))
         self.action_space = action_space
@@ -21,7 +21,7 @@ class ActionObserverEnv(gymnasium.Env):
         return observation, 0.0, False, False, {}
 
 
-class ConstantObservationEnv(gymnasium.Env):
+class ConstantObservationEnv(gym.Env):
     def __init__(self, constant: float):
         self.action_space = spaces.Box(-1.0, 1.0, shape=(1,))
         self.observation_space = spaces.Box(0.0, 2.0, shape=(1,))

--- a/upkie/envs/wrappers/tests/noisify_action_test.py
+++ b/upkie/envs/wrappers/tests/noisify_action_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.envs.wrappers.noisify_action import NoisifyAction
@@ -26,7 +26,7 @@ class NoisifyActionTestCase(unittest.TestCase):
         try:
             from stable_baselines3.common.env_checker import check_env
 
-            env = gymnasium.make("Pendulum-v1")
+            env = gym.make("Pendulum-v1")
             noisy_env = NoisifyAction(env, noise=np.full(1, 0.42))
             check_env(noisy_env)
         except ImportError:

--- a/upkie/envs/wrappers/tests/noisify_observation_test.py
+++ b/upkie/envs/wrappers/tests/noisify_observation_test.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-import gymnasium
+import gymnasium as gym
 import numpy as np
 
 from upkie.envs.wrappers.noisify_observation import NoisifyObservation
@@ -29,7 +29,7 @@ class NoisifyObservationTestCase(unittest.TestCase):
         try:
             from stable_baselines3.common.env_checker import check_env
 
-            env = gymnasium.make("Acrobot-v1")
+            env = gym.make("Acrobot-v1")
             noisy_env = NoisifyObservation(env, noise=np.full(6, 0.42))
             check_env(noisy_env)
         except ImportError:


### PR DESCRIPTION
- env: Remove unused `leg_return_period` and hard-code it to one second
- env: Replace contingent `parse_first_observation` by a reset override