### PR TITLE
Refactor the default Bullet spine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- utils: Add `clear_shared_memory` utility function
+
 ### Fixed
 
 - Bazel: Ignore `.pixi` directory as it can contain unrelated Bazel files

--- a/spines/BUILD
+++ b/spines/BUILD
@@ -20,6 +20,7 @@ cc_binary(
         "//upkie/cpp/observers:history_observer",
         "//upkie/cpp/sensors",
         "//upkie/cpp/spine",
+        "//upkie/cpp/utils:clear_shared_memory",
         "//upkie/cpp/utils:get_log_path",
         "//upkie/cpp:version",
     ],

--- a/spines/bullet_spine.cpp
+++ b/spines/bullet_spine.cpp
@@ -19,6 +19,7 @@
 #include "upkie/cpp/observers/WheelOdometry.h"
 #include "upkie/cpp/sensors/CpuTemperature.h"
 #include "upkie/cpp/spine/Spine.h"
+#include "upkie/cpp/utils/clear_shared_memory.h"
 #include "upkie/cpp/utils/get_log_path.h"
 #include "upkie/cpp/version.h"
 
@@ -36,6 +37,8 @@ using upkie::cpp::observers::ObserverPipeline;
 using upkie::cpp::observers::WheelOdometry;
 using upkie::cpp::sensors::CpuTemperature;
 using upkie::cpp::spine::Spine;
+using upkie::cpp::utils::clear_shared_memory;
+using upkie::cpp::utils::get_log_path;
 
 #ifndef __APPLE__
 using upkie::cpp::sensors::Joystick;

--- a/spines/mock_spine.cpp
+++ b/spines/mock_spine.cpp
@@ -114,7 +114,8 @@ class CommandLineArguments {
   bool version = false;
 };
 
-int main(const CommandLineArguments& args) {
+//! Build and run the mock spine.
+int run_spine(const CommandLineArguments& args) {
   if (!upkie::cpp::utils::lock_memory()) {
     spdlog::error("could not lock process memory to RAM");
     return -4;
@@ -183,5 +184,5 @@ int main(int argc, char** argv) {
     std::cout << "Upkie mock spine " << upkie::cpp::kVersion << "\n";
     return EXIT_SUCCESS;
   }
-  return spines::mock::main(args);
+  return spines::mock::run_spine(args);
 }

--- a/spines/pi3hat_spine.cpp
+++ b/spines/pi3hat_spine.cpp
@@ -146,6 +146,7 @@ inline bool calibration_needed() {
   return !file_found;
 }
 
+//! Build and run the pi3hat spine.
 int main(const CommandLineArguments& args) {
   if (calibration_needed()) {
     spdlog::error("Calibration needed: did you run `upkie_tool rezero`?");
@@ -240,5 +241,5 @@ int main(int argc, char** argv) {
     std::cout << "Upkie pi3hat spine " << upkie::cpp::kVersion << "\n";
     return EXIT_SUCCESS;
   }
-  return spines::pi3hat::main(args);
+  return spines::pi3hat::run_spine(args);
 }

--- a/spines/pi3hat_spine.cpp
+++ b/spines/pi3hat_spine.cpp
@@ -147,7 +147,7 @@ inline bool calibration_needed() {
 }
 
 //! Build and run the pi3hat spine.
-int main(const CommandLineArguments& args) {
+int run_spine(const CommandLineArguments& args) {
   if (calibration_needed()) {
     spdlog::error("Calibration needed: did you run `upkie_tool rezero`?");
     return -3;

--- a/upkie/cpp/utils/BUILD
+++ b/upkie/cpp/utils/BUILD
@@ -12,6 +12,11 @@ cc_library(
 )
 
 cc_library(
+    name = "clear_shared_memory",
+    hdrs = ["clear_shared_memory.h"],
+)
+
+cc_library(
     name = "get_log_path",
     hdrs = ["get_log_path.h"],
     deps = [
@@ -63,6 +68,7 @@ cc_library(
 cc_library(
     name = "utils",
     deps = [
+        ":clear_shared_memory",
         ":datetime_now_string",
         ":get_log_path",
         ":handle_interrupts",

--- a/upkie/cpp/utils/clear_shared_memory.h
+++ b/upkie/cpp/utils/clear_shared_memory.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Stéphane Caron
+
+#pragma once
+
+namespace upkie::cpp::utils {
+
+int clear_shared_memory(const std::string& name) {
+  const char* shm_name = name.c_str();
+  int file_descriptor = ::shm_open(shm_name, O_RDWR, 0666);
+  if (file_descriptor < 0) {
+    if (errno == ENOENT) {
+      return EXIT_SUCCESS;
+    } else if (errno == EINVAL) {
+      spdlog::error("Cannot clear shared memory (EINVAL: name '{}' invalid)",
+                    shm_name);
+      return EXIT_FAILURE;
+    } else {
+      spdlog::error(
+          "Cannot clear shared memory (error opening '{}', error number: {})",
+          shm_name, errno);
+      return EXIT_FAILURE;
+    }
+  }
+  if (::shm_unlink(shm_name) < 0) {
+    spdlog::error(
+        "Failed to unlink shared memory (name: '{}', error number: {})",
+        shm_name, errno);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+}  // namespace upkie::cpp::utils

--- a/upkie/cpp/utils/clear_shared_memory.h
+++ b/upkie/cpp/utils/clear_shared_memory.h
@@ -5,6 +5,11 @@
 
 namespace upkie::cpp::utils {
 
+/*! Clear an existing shared-memory file.
+ *
+ * \param[in] name Name of the shared-memory file to remove if it exists.
+ * \return EXIT_SUCCESS if the file is cleared, EXIT_FAILURE otherwise.
+ */
 int clear_shared_memory(const std::string& name) {
   const char* shm_name = name.c_str();
   int file_descriptor = ::shm_open(shm_name, O_RDWR, 0666);

--- a/upkie/cpp/utils/clear_shared_memory.h
+++ b/upkie/cpp/utils/clear_shared_memory.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace upkie::cpp::utils {
 
 /*! Clear an existing shared-memory file.


### PR DESCRIPTION
This PR refactors the Bullet spine so that it explains itself a bit more. It moves `clear_shared_memory` to utilities, as it can be re-used by other derivative spines.