### PR TITLE
Release v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2025-03-10
+
 ### Added
 
 - Add pixi-pack integration
@@ -736,7 +738,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Starting this changelog.
 
-[unreleased]: https://github.com/upkie/upkie/compare/v6.1.0...HEAD
+[unreleased]: https://github.com/upkie/upkie/compare/v7.0.0...HEAD
+[7.0.0]: https://github.com/upkie/upkie/compare/v6.1.0...v7.0.0
 [6.1.0]: https://github.com/upkie/upkie/compare/v6.0.0...v6.1.0
 [6.0.0]: https://github.com/upkie/upkie/compare/v5.2.0...v6.0.0
 [5.2.0]: https://github.com/upkie/upkie/compare/v5.1.0...v5.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "Upkie open source wheeled biped robot"
-version: 6.1.0
-date-released: 2024-11-01
+version: 7.0.0
+date-released: 2025-03-10
 url: "https://github.com/upkie/upkie"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ If you built an Upkie or use parts of this project in your works, please cite th
   author = {Caron, St\'{e}phane and Perrin-Gilbert, Nicolas and Ledoux, Viviane and G\"{o}kbakan, \"{Umit} Bora and Raverdy, Pierre-Guillaume and Raffin, Antonin and Tordjman--Levavasseur, Valentin},
   url = {https://github.com/upkie/upkie},
   license = {Apache-2.0},
-  version = {6.1.0},
-  year = {2024}
+  version = {7.0.0},
+  year = {2025}
 }
 ```
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = upkie
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 6.1.0
+PROJECT_NUMBER         = 7.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/upkie/__init__.py
+++ b/upkie/__init__.py
@@ -6,4 +6,4 @@
 
 """Python module to control Upkie wheeled bipeds."""
 
-__version__ = "6.1.0"
+__version__ = "7.0.0"

--- a/upkie/cpp/version.h
+++ b/upkie/cpp/version.h
@@ -15,6 +15,6 @@
 namespace upkie::cpp {
 
 //! Software version number.
-constexpr std::string_view kVersion = "6.1.0";
+constexpr std::string_view kVersion = "7.0.0";
 
 }  // namespace upkie::cpp


### PR DESCRIPTION
This release adds collision observations to simulation environments, pixi-pack integration and additional unit tests. It is a major release as `get_reward` functions have been removed from all Gymnasium environments. Otherwise comes a regular batch of fixes and additions to the documentation.

Thanks to @Tordjx for contributing to this release :+1: 

### Added

- Add pixi-pack integration
- actuation: Add collision-with-environment observation (thanks to @Tordjx)
- docs: Start Kinematics page
- utils: Add `clear_shared_memory` utility function

### Changed

- Bazel: Treat warnings as errors (except the one we can't avoid)
- Minimum Python version is now 3.9
- envs: Observation-based reward wrapper
- envs: Unit test for the base `step` function
- examples: Group simulation-related examples in a sub-directory

### Fixed

- Bazel: Ignore `.pixi` directory as it can contain unrelated Bazel files
- Fix unused variable warning in Bullet interface

### Removed

- **Breaking:** Remove `get_reward` functions from all environments
- Makefile: Remove conda packing rules, now deprecated in favor of pixi