### PR TITLE
Release v9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.1] - 2025-09-10
+
 ### Added
 
-- examples: Add `uv` dependencies to example scripts
+- examples: Add PEP-723 inline dependencies to example scripts
 
 ### Fixed
 
@@ -891,7 +893,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Starting this changelog.
 
-[unreleased]: https://github.com/upkie/upkie/compare/v9.0.0...HEAD
+[unreleased]: https://github.com/upkie/upkie/compare/v9.0.1...HEAD
+[9.0.1]: https://github.com/upkie/upkie/compare/v9.0.0...v9.0.1
 [9.0.0]: https://github.com/upkie/upkie/compare/v8.1.1...v9.0.0
 [8.1.1]: https://github.com/upkie/upkie/compare/v8.1.0...v8.1.1
 [8.1.0]: https://github.com/upkie/upkie/compare/v8.0.0...v8.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "Upkie open source wheeled biped robot"
-version: 9.0.0
-date-released: 2025-08-14
+version: 9.0.1
+date-released: 2025-09-10
 url: "https://github.com/upkie/upkie"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you built an Upkie or use parts of this project in your works, please cite th
   author = {Caron, St\'{e}phane and Perrin-Gilbert, Nicolas and Ledoux, Viviane and G\"{o}kbakan, \"{U}mit Bora and Raverdy, Pierre-Guillaume and Raffin, Antonin and Tordjman--Levavasseur, Valentin},
   url = {https://github.com/upkie/upkie},
   license = {Apache-2.0},
-  version = {9.0.0},
+  version = {9.0.1},
   year = {2025}
 }
 ```

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = upkie
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 9.0.0
+PROJECT_NUMBER         = 9.0.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/upkie/__init__.py
+++ b/upkie/__init__.py
@@ -8,7 +8,7 @@
 
 from . import config, envs, model, utils
 
-__version__ = "9.0.0"
+__version__ = "9.0.1"
 
 __all__ = [
     "config",

--- a/upkie/cpp/version.h
+++ b/upkie/cpp/version.h
@@ -15,6 +15,6 @@
 namespace upkie::cpp {
 
 //! Software version number.
-constexpr std::string_view kVersion = "9.0.0";
+constexpr std::string_view kVersion = "9.0.1";
 
 }  // namespace upkie::cpp


### PR DESCRIPTION
This patch release fixes odometry configuration in PyBullet simulations, as well as a compilation error for the keyboard sensor on ARM64 macOS.

### Added

- examples: Add PEP-723 inline dependencies to example scripts

### Fixed

- envs: Use wheel radius from robot configuration in PyBullet odometry
- sensors: Fix keyboard build error on ARM64 macOS