### PR TITLE
Add environment with base-velocity commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- envs: Add `UpkieNavigation` environment
+
 ### Fixed
 
 - utils: Fix square and triangle button observations in Python

--- a/examples/pybullet_navigation.py
+++ b/examples/pybullet_navigation.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Upkie Team
+#
+# /// script
+# dependencies = ["upkie", "proxsuite", "pybullet>=3", "qpmdc"]
+# ///
+
+"""Navigation example using UpkieNavigation in PyBullet simulation."""
+
+import gymnasium as gym
+import numpy as np
+
+import upkie.envs
+
+upkie.envs.register()
+
+NB_STEPS = 8_000
+SIDE_LENGTH = 0.5  # meters (50 cm)
+
+
+def follow_square_trajectory(step_count: int, total_steps: int) -> np.ndarray:
+    steps_per_side = total_steps // 4
+    step_in_side = step_count % steps_per_side
+    linear_velocity = 0.2  # m/s
+    angular_velocity = 0.5  # rad/s
+    frequency = 200.0
+    dt = 1.0 / frequency
+
+    forward_steps = int(SIDE_LENGTH / linear_velocity / dt)  # 200 Hz
+    if step_in_side < forward_steps:
+        return np.array([linear_velocity, 0.0])
+    else:
+        # Turn left 90 degrees
+        return np.array([0.0, angular_velocity])
+
+
+if __name__ == "__main__":
+    with gym.make(
+        "Upkie-PyBullet-Navigation",
+        frequency=200.0,  # Hz
+        frequency_checks=False,  # no real-time check as simulator runs in step
+        gui=True,
+        nb_substeps=5,
+        max_linear_velocity=1.0,  # m/s
+        max_angular_velocity=2.0,  # rad/s
+    ) as env:
+        _, info = env.reset()  # connects to the spine
+
+        print("\n-----\n")
+        print(f"Tracking a square for {NB_STEPS} steps...")
+        print(f"Square side: {SIDE_LENGTH} m")
+        print("Press Ctrl+C to stop early.\n")
+
+        for step in range(NB_STEPS):
+            action = follow_square_trajectory(step, NB_STEPS)
+            observation, _, terminated, truncated, info = env.step(action)
+
+            # Print progress every 500 steps
+            if (step + 1) % 500 == 0:
+                x, y, theta = observation
+                print(
+                    f"Step {step + 1:5d}: "
+                    f"Position = ({x:6.3f}, {y:6.3f}) m, "
+                    f"Orientation = {theta:6.3f} rad "
+                    f"({np.degrees(theta):6.1f}°)"
+                )
+
+            if terminated or truncated:
+                print("Episode ended, resetting...")
+                _, info = env.reset()
+
+        print("Navigation example completed.")

--- a/pixi.lock
+++ b/pixi.lock
@@ -580,7 +580,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -752,7 +752,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.32-openmp_h1a8b088_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.1-hf685517_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -907,7 +907,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.1-he8aa2a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
@@ -2041,7 +2041,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -2173,7 +2173,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.32-pthreads_h9d3fd7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.3-h44a3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -2299,7 +2299,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-1.0.0-np2py313hd6693e2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.8-ha1acc90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
@@ -2437,7 +2437,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -2571,7 +2571,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.32-pthreads_h9d3fd7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.3-h44a3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -2700,7 +2700,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-1.0.0-np2py313hd6693e2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.8-ha1acc90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
@@ -2841,7 +2841,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -2973,7 +2973,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.32-pthreads_h9d3fd7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.3-h44a3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -3100,7 +3100,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-1.0.0-np2py313hd6693e2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.8-ha1acc90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
@@ -3239,7 +3239,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -3371,7 +3371,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.32-pthreads_h9d3fd7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.3-h44a3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -3498,7 +3498,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-1.0.0-np2py313hd6693e2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.8-ha1acc90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
@@ -3637,7 +3637,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
@@ -3769,7 +3769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.32-pthreads_h9d3fd7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.3-h44a3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
@@ -3895,7 +3895,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-1.0.0-np2py313hd6693e2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.8-ha1acc90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
@@ -8906,37 +8906,37 @@ packages:
   purls: []
   size: 29512
   timestamp: 1749901899881
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
-  sha256: 06323fb0a831440f0b72a53013182e1d4bb219e3ea958bb37af98b25dc0cf518
-  md5: 06f225e6d8c549ad6c0201679828a882
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+  sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+  md5: eba48a68a1a2b9d3c0d9511548db85db
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317779
-  timestamp: 1775692841709
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.57-h1abf092_0.conda
-  sha256: 61dc9dd114be174bef444c37a8f2db37342c4cc7c0f0ddeadbaefbd0b4422a9f
-  md5: 41ba1a3e77b5aeb55bc2b9a206760f6a
+  size: 317729
+  timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+  sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
+  md5: f51503ac45a4888bce71af9027a2ecc9
   depends:
   - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 341304
-  timestamp: 1775692856058
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.57-h132b30e_0.conda
-  sha256: 3f2b76a220844a7b2217688910d59c5fce075f54d0cee03da55a344e6be8f8a0
-  md5: 1a28041d8d998688fd82e25b45582b21
+  size: 341202
+  timestamp: 1776315188425
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+  sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
+  md5: 2259ae0949dbe20c0665850365109b27
   depends:
   - __osx >=11.0
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 289615
-  timestamp: 1775692978357
+  size: 289546
+  timestamp: 1776315246750
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
   sha256: 51125ebb8b7152e4a4e69fd2398489c4ec8473195c27cde3cbdf1cb6d18c5493
   md5: d8703f1ffe5a06356f06467f1d0b9464
@@ -11791,6 +11791,7 @@ packages:
   - python >=3.8
   - python
   license: Apache-2.0
+  license_family: APACHE
   purls:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 89360
@@ -14746,7 +14747,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytz?source=compressed-mapping
+  - pkg:pypi/pytz?source=hash-mapping
   size: 201725
   timestamp: 1773679724369
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
@@ -16659,6 +16660,7 @@ packages:
   - typing_extensions >=4.13.2
   - python
   license: MIT
+  license_family: MIT
   purls:
   - pkg:pypi/virtualenv?source=compressed-mapping
   size: 4659433

--- a/tests/envs/test_upkie_navigation.py
+++ b/tests/envs/test_upkie_navigation.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Upkie Team
+
+"""Test UpkieNavigation wrapper."""
+
+import unittest
+
+import numpy as np
+
+from upkie.envs.backends import MockBackend
+from upkie.envs.upkie_navigation import UpkieNavigation
+from upkie.envs.upkie_pendulum import UpkiePendulum
+from upkie.envs.upkie_servos import UpkieServos
+
+
+class NavigationTestCase(unittest.TestCase):
+    def setUp(self):
+        """Set up test environment with mock backend."""
+        self.backend = MockBackend()
+        servos_env = UpkieServos(
+            backend=self.backend,
+            frequency=100.0,
+        )
+        pendulum_env = UpkiePendulum(
+            servos_env,
+            fall_pitch=1.0,
+            max_ground_velocity=1.0,
+        )
+        navigation_env = UpkieNavigation(
+            pendulum_env,
+            max_linear_velocity=1.0,
+            max_angular_velocity=2.0,
+        )
+        self.servos_env = servos_env
+        self.pendulum_env = pendulum_env
+        self.env = navigation_env
+
+    def test_action_space_dtype(self):
+        """Test that action space has correct dtype np.float32."""
+        self.assertEqual(self.env.action_space.dtype, np.float32)
+        self.assertEqual(self.env.action_space.shape, (2,))
+        # Test limits
+        np.testing.assert_array_equal(
+            self.env.action_space.low, np.array([-1.0, -2.0], dtype=np.float32)
+        )
+        np.testing.assert_array_equal(
+            self.env.action_space.high, np.array([1.0, 2.0], dtype=np.float32)
+        )
+
+    def test_observation_space_dtype(self):
+        """Test that observation space has correct dtype."""
+        # UpkieNavigation observation space should be float (not float32)
+        self.assertEqual(self.env.observation_space.dtype, float)
+        self.assertEqual(self.env.observation_space.shape, (3,))
+        # Check SE(2) limits: [x, y, theta]
+        expected_low = np.array([-np.inf, -np.inf, -np.pi], dtype=float)
+        expected_high = np.array([np.inf, np.inf, np.pi], dtype=float)
+        np.testing.assert_array_equal(
+            self.env.observation_space.low, expected_low
+        )
+        np.testing.assert_array_equal(
+            self.env.observation_space.high, expected_high
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/envs/test_upkie_pendulum.py
+++ b/tests/envs/test_upkie_pendulum.py
@@ -102,29 +102,6 @@ class PendulumTestCase(unittest.TestCase):
         observation, _, _, _, _ = self.env.step(action)
         self.assertEqual(observation.dtype, np.float32)
 
-    def test_frequency_validation_missing_attribute(self):
-        """An exception is raised when the environment has no frequency."""
-
-        class MockEnvWithoutFrequency(gym.Env):
-            """Mock environment that doesn't have frequency attribute."""
-
-            def __init__(self):
-                # Don't set frequency attribute
-                pass
-
-            def step(self, action):
-                return None, 0.0, False, False, {}
-
-            def reset(self, **kwargs):
-                return None, {}
-
-        mock_env = MockEnvWithoutFrequency()
-
-        with self.assertRaises(UpkieException) as context:
-            UpkiePendulum(mock_env)
-
-        self.assertIn("frequency", str(context.exception))
-
     def test_frequency_validation_none_value(self):
         """An exception is raised when environment has a None frequency."""
 

--- a/tests/envs/test_upkie_pendulum.py
+++ b/tests/envs/test_upkie_pendulum.py
@@ -8,12 +8,14 @@
 import unittest
 from multiprocessing.shared_memory import SharedMemory
 
+import gymnasium as gym
 import numpy as np
 
 from upkie.envs.backends import SpineBackend
 from upkie.envs.testing import MockSpine
 from upkie.envs.upkie_pendulum import UpkiePendulum
 from upkie.envs.upkie_servos import UpkieServos
+from upkie.exceptions import UpkieException
 
 
 class PendulumTestCase(unittest.TestCase):
@@ -104,6 +106,51 @@ class PendulumTestCase(unittest.TestCase):
         action = np.zeros(self.env.action_space.shape, dtype=np.float32)
         observation, _, _, _, _ = self.env.step(action)
         self.assertEqual(observation.dtype, np.float32)
+
+    def test_frequency_validation_missing_attribute(self):
+        """An exception is raised when the environment has no frequency."""
+
+        class MockEnvWithoutFrequency(gym.Env):
+            """Mock environment that doesn't have frequency attribute."""
+
+            def __init__(self):
+                # Don't set frequency attribute
+                pass
+
+            def step(self, action):
+                return None, 0.0, False, False, {}
+
+            def reset(self, **kwargs):
+                return None, {}
+
+        mock_env = MockEnvWithoutFrequency()
+
+        with self.assertRaises(UpkieException) as context:
+            UpkiePendulum(mock_env)
+
+        self.assertIn("frequency", str(context.exception))
+
+    def test_frequency_validation_none_value(self):
+        """An exception is raised when environment has a None frequency."""
+
+        class MockEnvWithNoneFrequency(gym.Env):
+            """Mock environment with frequency set to None."""
+
+            def __init__(self):
+                self.frequency = None
+
+            def step(self, action):
+                return None, 0.0, False, False, {}
+
+            def reset(self, **kwargs):
+                return None, {}
+
+        mock_env = MockEnvWithNoneFrequency()
+
+        with self.assertRaises(UpkieException) as context:
+            UpkiePendulum(mock_env)
+
+        self.assertIn("frequency", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/envs/test_upkie_pendulum.py
+++ b/tests/envs/test_upkie_pendulum.py
@@ -6,13 +6,11 @@
 """Test UpkiePendulum wrapper."""
 
 import unittest
-from multiprocessing.shared_memory import SharedMemory
 
 import gymnasium as gym
 import numpy as np
 
-from upkie.envs.backends import SpineBackend
-from upkie.envs.testing import MockSpine
+from upkie.envs.backends import MockBackend
 from upkie.envs.upkie_pendulum import UpkiePendulum
 from upkie.envs.upkie_servos import UpkieServos
 from upkie.exceptions import UpkieException
@@ -20,19 +18,16 @@ from upkie.exceptions import UpkieException
 
 class PendulumTestCase(unittest.TestCase):
     def setUp(self):
-        shared_memory = SharedMemory(name=None, size=42, create=True)
-        self.backend = SpineBackend(shm_name=shared_memory._name)
+        self.backend = MockBackend()
         servos_env = UpkieServos(
             backend=self.backend,
             frequency=100.0,
         )
-        self.backend._spine = MockSpine()
         pendulum = UpkiePendulum(
             servos_env,
             fall_pitch=1.0,
             max_ground_velocity=1.0,
         )
-        shared_memory.close()
         self.servos_env = servos_env
         self.env = pendulum
 
@@ -50,7 +45,7 @@ class PendulumTestCase(unittest.TestCase):
         observation, reward, terminated, truncated, _ = self.env.step(action)
         self.assertNotEqual(reward, 0.0)  # non-zero base velocity
 
-        spine_observation = self.backend._spine.observation
+        spine_observation = self.backend.get_spine_observation()
         base_orientation = spine_observation["base_orientation"]
         base_orientation["pitch"] = 0.0
         base_orientation["angular_velocity"] = [0.0, 0.0, 0.0]
@@ -70,7 +65,7 @@ class PendulumTestCase(unittest.TestCase):
         _, _ = self.env.reset()
         action = np.zeros(self.env.action_space.shape)
         _, _, _, _, _ = self.env.step(action)
-        spine_action = self.backend._spine.action
+        spine_action = self.backend.get_last_action()
         servo_action = spine_action["servo"]
         model = self.env.get_wrapper_attr("model")
         for joint in model.upper_leg_joints:
@@ -84,7 +79,7 @@ class PendulumTestCase(unittest.TestCase):
         _, _ = self.env.reset()
         action = np.full(self.env.action_space.shape, 1111.1)
         _, _, _, _, _ = self.env.step(action)
-        spine_action = self.backend._spine.action
+        spine_action = self.backend.get_last_action()
         servo_action = spine_action["servo"]
         max_ground_velocity = self.env.action_space.high[0]
         model = self.env.get_wrapper_attr("model")

--- a/upkie/envs/__init__.py
+++ b/upkie/envs/__init__.py
@@ -13,6 +13,7 @@ import gymnasium as gym
 from .upkie_base_velocity import UpkieBaseVelocity
 from .upkie_env import UpkieEnv
 from .upkie_gyropod import UpkieGyropod
+from .upkie_navigation import UpkieNavigation
 from .upkie_pendulum import UpkiePendulum
 from .upkie_servos import UpkieServos
 
@@ -51,6 +52,7 @@ __all__ = [
     "UpkieBaseVelocity",
     "UpkieEnv",
     "UpkieGyropod",
+    "UpkieNavigation",
     "UpkiePendulum",
     "UpkieServos",
     "register",

--- a/upkie/envs/backends/mock_backend.py
+++ b/upkie/envs/backends/mock_backend.py
@@ -69,6 +69,7 @@ class MockBackend(Backend):
         joystick = Joystick(js_path) if js_path.exists() else None
 
         self.__dt = 0.01  # Default timestep in seconds
+        self.__last_action = {}  # Store last action for testing
         self.__spine_observation = spine_observation
         self.__wheel_radius = 0.06  # Default wheel radius in meters
         self.joystick = joystick
@@ -86,6 +87,7 @@ class MockBackend(Backend):
         \param init_state Initial state of the robot (ignored in mock).
         \return Initial spine observation dictionary.
         """
+        self.__spine_observation["number"] += 1
         return self.get_spine_observation()
 
     def step(self, action: dict) -> dict:
@@ -95,8 +97,10 @@ class MockBackend(Backend):
         \param action Action dictionary in spine format.
         \return Spine observation dictionary after the step.
         """
+        self.__last_action = action.copy()  # Store action for testing
         self.__update_servo(action)
         self.__update_wheel_odometry()
+        self.__spine_observation["number"] += 1
 
         if self.joystick is not None:
             self.joystick.write(self.__spine_observation)
@@ -133,6 +137,12 @@ class MockBackend(Backend):
         new_position = current_position + ground_velocity * self.__dt
         wheel_odometry["position"] = new_position
         wheel_odometry["velocity"] = ground_velocity
+
+    def get_last_action(self) -> dict:
+        r"""!
+        Get the last action sent to the mock backend.
+        """
+        return self.__last_action
 
     def get_spine_observation(self) -> dict:
         r"""!

--- a/upkie/envs/entry_points.py
+++ b/upkie/envs/entry_points.py
@@ -11,6 +11,7 @@ from upkie.envs.backends import (
 )
 from upkie.envs.upkie_base_velocity import UpkieBaseVelocity
 from upkie.envs.upkie_gyropod import UpkieGyropod
+from upkie.envs.upkie_navigation import UpkieNavigation
 from upkie.envs.upkie_pendulum import UpkiePendulum
 from upkie.exceptions import MissingOptionalDependency
 from upkie.model import Model
@@ -486,3 +487,34 @@ def make_cookie_spine_pendulum(**kwargs):
     Add pendulum wrapper around a Cookie servos env with Spine backend.
     """
     return wrap_spine_pendulum(**kwargs)
+
+
+def wrap_navigation(make_env_func, **kwargs):
+    r"""!
+    Make a navigation environment around a pendulum environment.
+
+    This function is meant to be called by `gymnasium.make()` rather than to be
+    called directly.
+
+    \param make_env_func Function that creates the base servo environment.
+    \param kwargs Keyword arguments forwarded to both the
+        \ref upkie.envs.upkie_navigation.UpkieNavigation wrapper and the
+        internal Upkie environment.
+    \return UpkieNavigation environment.
+    """
+    navigation_keys = {
+        "max_linear_velocity",
+        "max_angular_velocity",
+    }
+    navigation_kwargs = {
+        key: value for key, value in kwargs.items() if key in navigation_keys
+    }
+    pendulum_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key not in navigation_keys
+    }
+
+    # Create pendulum environment first
+    pendulum_env = wrap_pendulum(make_env_func, **pendulum_kwargs)
+    return UpkieNavigation(pendulum_env, **navigation_kwargs)

--- a/upkie/envs/upkie_navigation.py
+++ b/upkie/envs/upkie_navigation.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Upkie Team
+
+from typing import Dict, Optional, Tuple
+
+import gymnasium as gym
+import numpy as np
+
+from upkie.controllers.mpc_balancer import MPCBalancer
+from upkie.envs.upkie_pendulum import UpkiePendulum
+from upkie.utils.clamp import clamp_and_warn
+
+
+class UpkieNavigation(gym.Wrapper):
+    r"""!
+    Wrapper to make Upkie act as a differential drive robot in SE(2).
+
+    This wrapper allows Upkie to navigate in the 2D plane by keeping its legs
+    straight and commanding wheel velocities for differential drive motion. The
+    robot's pose \f[(x, y, \theta)\f] is estimated by wheel odometry.
+
+    ### Action space
+
+    The action corresponds to desired linear and angular velocities:
+
+    \f[
+    a = \begin{bmatrix} v \\ \omega \end{bmatrix}
+    \f]
+
+    where:
+    - \f$v\f$ is the linear velocity in m/s (forward/backward)
+    - \f$\omega\f$ is the angular velocity in rad/s (yaw rotation)
+
+    ### Observation space
+
+    The observation is the robot's pose in SE(2):
+
+    \f[
+    o = \begin{bmatrix} x \\ y \\ \theta \end{bmatrix}
+    \f]
+
+    where:
+    - \f$x\f$ is the position along the x-axis in meters
+    - \f$y\f$ is the position along the y-axis in meters
+    - \f$\theta\f$ is the yaw angle in radians
+    """
+
+    action_space: gym.spaces.Box
+    env: UpkiePendulum
+    mpc_balancer: MPCBalancer
+    observation_space: gym.spaces.Box
+
+    def __init__(
+        self,
+        env: UpkiePendulum,
+        max_linear_velocity: float = 1.0,
+        max_angular_velocity: float = 2.0,
+    ):
+        r"""!
+        Initialize navigation environment.
+
+        \param env UpkiePendulum environment to wrap.
+        \param max_linear_velocity Maximum linear velocity in m/s.
+        \param max_angular_velocity Maximum angular velocity in rad/s.
+        """
+        super().__init__(env)
+
+        # Observation limits for SE(2) pose
+        MAX_POSITION: float = float("inf")
+        MAX_ANGLE: float = np.pi
+        observation_limit = np.array(
+            [MAX_POSITION, MAX_POSITION, MAX_ANGLE],
+            dtype=float,
+        )
+
+        # Action limits for [linear_velocity, angular_velocity]
+        action_limit = np.array(
+            [max_linear_velocity, max_angular_velocity], dtype=np.float32
+        )
+
+        # gymnasium.Env: observation_space
+        self.observation_space = gym.spaces.Box(
+            -observation_limit,
+            +observation_limit,
+            shape=observation_limit.shape,
+            dtype=observation_limit.dtype,
+        )
+
+        # gymnasium.Env: action_space
+        self.action_space = gym.spaces.Box(
+            -action_limit,
+            +action_limit,
+            shape=action_limit.shape,
+            dtype=action_limit.dtype,
+        )
+
+        # MPC balancer
+        mpc_balancer = MPCBalancer(
+            leg_length=0.58,  # Default leg length
+            fall_pitch=1.0,  # Use default fall pitch
+            max_ground_accel=1.0,
+            max_ground_velocity=max_linear_velocity,
+        )
+
+        # Instance attributes
+        self.__last_spine_observation = {}
+        self.env = env
+        self.mpc_balancer = mpc_balancer
+        self.last_ground_position = 0.0
+        self.pose = np.zeros(3)  # [x, y, theta]
+
+    def __get_env_observation(self, spine_observation: dict) -> np.ndarray:
+        r"""!
+        Extract environment observation from spine observation dictionary.
+
+        \param spine_observation Spine observation dictionary.
+        \return Environment observation vector (SE(2) pose).
+        """
+        cur_ground_position = spine_observation["wheel_odometry"]["position"]
+        displacement = cur_ground_position - self.last_ground_position
+        self.last_ground_position = cur_ground_position
+
+        # Update pose by integrating displacement
+        self.pose[0] += displacement * np.cos(self.pose[2])  # x
+        self.pose[1] += displacement * np.sin(self.pose[2])  # y
+        # theta is updated in step() based on target yaw velocity
+
+        return self.pose.copy()
+
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Optional[dict] = None,
+    ) -> Tuple[np.ndarray, Dict]:
+        r"""!
+        Resets the environment and get an initial observation.
+
+        \param seed Number used to initialize the environment's internal random
+            number generator.
+        \param options Currently unused.
+        \return
+            - `observation`: Initial SE(2) pose observation.
+            - `info`: Dictionary with auxiliary diagnostic information.
+        """
+        _, info = self.env.reset(seed=seed, options=options)
+        spine_observation = info["spine_observation"]
+        self.__last_spine_observation = spine_observation
+
+        # Reset pose tracking
+        self.pose = np.zeros(3)
+        self.last_ground_position = spine_observation["wheel_odometry"][
+            "position"
+        ]
+
+        observation = self.__get_env_observation(spine_observation)
+        return observation, info
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> Tuple[np.ndarray, float, bool, bool, dict]:
+        r"""!
+        Run one timestep of the environment's dynamics.
+
+        \param action Action from the agent [linear, angular velocities].
+        \return
+            - `observation`: SE(2) pose observation.
+            - `reward`: Reward returned after taking the action.
+            - `terminated`: Whether the agent reached a terminal state.
+            - `truncated`: Whether the episode is reaching max number of steps.
+            - `info`: Dictionary with additional information.
+        """
+        # Clamp actions
+        target_ground_velocity = clamp_and_warn(
+            action[0],
+            self.action_space.low[0],
+            self.action_space.high[0],
+            label="linear_velocity",
+        )
+        target_yaw_velocity = clamp_and_warn(
+            action[1],
+            self.action_space.low[1],
+            self.action_space.high[1],
+            label="angular_velocity",
+        )
+
+        # Update theta estimate based on target angular velocity
+        dt = self.env.unwrapped.dt
+        self.pose[2] += target_yaw_velocity * dt
+        # Normalize angle to [-pi, pi]
+        self.pose[2] = np.arctan2(np.sin(self.pose[2]), np.cos(self.pose[2]))
+
+        # Use MPC balancer to compute balanced ground velocity
+        ground_velocity = self.mpc_balancer.compute_ground_velocity(
+            target_ground_velocity, self.__last_spine_observation, dt
+        )
+
+        # Call the UpkiePendulum step function
+        _, reward, terminated, truncated, info = self.env.step(
+            action=np.array([ground_velocity])
+        )
+
+        # Get our navigation observation
+        spine_observation = info["spine_observation"]
+        observation = self.__get_env_observation(spine_observation)
+        self.__last_spine_observation = spine_observation
+
+        return observation, reward, terminated, truncated, info

--- a/upkie/envs/upkie_pendulum.py
+++ b/upkie/envs/upkie_pendulum.py
@@ -104,6 +104,10 @@ class UpkiePendulum(gym.Wrapper):
             dtype=np.float32,
         )
 
+        # Instance attributes
+        self.env = gyropod_env.unwrapped
+        self.fall_pitch = fall_pitch
+
     def reset(
         self,
         *,


### PR DESCRIPTION
THis PR was an initial attempt at a higher-level environment where the agent would provide target base linear (sagittal) and angular (yaw) velocities only, and the environment would take care of balancing under the hood.

**Edit::** [now implemented](https://github.com/upkie/upkie/pull/553) in the `UpkieBaseVelocity` environment.