### PR TITLE
Release v11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0] - 2026-04-07
+
 ### Added
 
 - CICD: Add optional pre-commit checks
 - CICD: Add unit tests for the Python `Joystick` class
 - CICD: Test joystick usage in the PyBullet backend.
 - config: Allow both .yaml and .yml file extensions
-- controllers: Add `JoystickGyropodController` mapping joystick inputs to gyropod actions
+- controllers: Add `JoystickController` mapping joystick inputs to linear-angular velocities
 - controllers: Add `reset` function to `MPCBalancer`
 - controllers: Rename MPCBalancer stepping function to `step`
 - envs: Add `UpkieBaseVelocity` environment
@@ -50,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model: Derive `Model.wheel_base` from robot descriptions
 - model: Derive `Model.wheel_radius` from robot descriptions
 - model: Move URDF processing to `KinematicTree` class
-- mpc_balancer: Merge `RemoteControl` parameters into the new `JoystickGyropodController`
+- mpc_balancer: Merge `RemoteControl` parameters into the new `JoystickController`
 - mpc_balancer: Merge `WheelController` into `Controller` class
 - mpc_balancer: Moved to `examples/real_robot/follow_joystick.py`
 - mpc_balancer: Use left rather than right joystick's left-right axis for yaw control
@@ -73,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - config: Remove robot configuration dictionary as it has become unused
 - cpp: Remove unused `follower_camera` parameter from the Bullet interface
 - examples: Remove PI balancing variant from real-robot examples
-- mpc_balancer: Remove `RemoteControl` class as it is now in `JoystickGyropodController`
+- mpc_balancer: Remove `RemoteControl` class as it is now in `JoystickController`
 - mpc_balancer: Remove `WheelController` class as it is now in the `UpkieGyropod` environment
 
 ## [10.1.0] - 2026-03-11
@@ -1032,42 +1034,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Starting this changelog.
 
-[unreleased]: https://github.com/upkie/upkie/compare/v10.1.0...HEAD
-[10.1.0]: https://github.com/upkie/upkie/compare/v10.0.0...v10.1.0
-[10.0.0]: https://github.com/upkie/upkie/compare/v9.0.1...v10.0.0
-[9.0.1]: https://github.com/upkie/upkie/compare/v9.0.0...v9.0.1
-[9.0.0]: https://github.com/upkie/upkie/compare/v8.1.1...v9.0.0
-[8.1.1]: https://github.com/upkie/upkie/compare/v8.1.0...v8.1.1
-[8.1.0]: https://github.com/upkie/upkie/compare/v8.0.0...v8.1.0
-[8.0.0]: https://github.com/upkie/upkie/compare/v7.0.0...v8.0.0
-[7.0.0]: https://github.com/upkie/upkie/compare/v6.1.0...v7.0.0
-[6.1.0]: https://github.com/upkie/upkie/compare/v6.0.0...v6.1.0
-[6.0.0]: https://github.com/upkie/upkie/compare/v5.2.0...v6.0.0
-[5.2.0]: https://github.com/upkie/upkie/compare/v5.1.0...v5.2.0
-[5.1.0]: https://github.com/upkie/upkie/compare/v5.0.1...v5.1.0
-[5.0.1]: https://github.com/upkie/upkie/compare/v5.0.0...v5.0.1
-[5.0.0]: https://github.com/upkie/upkie/compare/v4.0.0...v5.0.0
-[4.0.0]: https://github.com/upkie/upkie/compare/v3.4.0...v4.0.0
-[3.4.0]: https://github.com/upkie/upkie/compare/v3.3.0...v3.4.0
-[3.3.0]: https://github.com/upkie/upkie/compare/v3.2.0...v3.3.0
-[3.2.0]: https://github.com/upkie/upkie/compare/v3.1.0...v3.2.0
-[3.1.0]: https://github.com/upkie/upkie/compare/v3.0.0...v3.1.0
-[3.0.0]: https://github.com/upkie/upkie/compare/v2.0.0...v3.0.0
-[2.0.0]: https://github.com/upkie/upkie/compare/v1.5.0...v2.0.0
-[1.5.0]: https://github.com/upkie/upkie/compare/v1.4.0...v1.5.0
-[1.4.0]: https://github.com/upkie/upkie/compare/v1.3.4...v1.4.0
-[1.3.4]: https://github.com/upkie/upkie/compare/v1.3.3...v1.3.4
-[1.3.3]: https://github.com/upkie/upkie/compare/v1.3.2...v1.3.3
-[1.3.2]: https://github.com/upkie/upkie/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/upkie/upkie/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/upkie/upkie/compare/v1.2.1...v1.3.0
-[1.2.1]: https://github.com/upkie/upkie/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/upkie/upkie/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/upkie/upkie/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/upkie/upkie/compare/v0.5.0...v1.0.0
-[0.5.0]: https://github.com/upkie/upkie/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/upkie/upkie/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/upkie/upkie/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/upkie/upkie/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/upkie/upkie/compare/v0.1.0...v0.2.0
+[unreleased]: https://github.com/upkie/upkie/compare/v11.0.0...HEAD
+[11.0.0]: https://github.com/upkie/upkie/releases/tag/v11.0.0
+[10.1.0]: https://github.com/upkie/upkie/releases/tag/v10.1.0
+[10.0.0]: https://github.com/upkie/upkie/releases/tag/v10.0.0
+[9.0.1]: https://github.com/upkie/upkie/releases/tag/v9.0.1
+[9.0.0]: https://github.com/upkie/upkie/releases/tag/v9.0.0
+[8.1.1]: https://github.com/upkie/upkie/releases/tag/v8.1.1
+[8.1.0]: https://github.com/upkie/upkie/releases/tag/v8.1.0
+[8.0.0]: https://github.com/upkie/upkie/releases/tag/v8.0.0
+[7.0.0]: https://github.com/upkie/upkie/releases/tag/v7.0.0
+[6.1.0]: https://github.com/upkie/upkie/releases/tag/v6.1.0
+[6.0.0]: https://github.com/upkie/upkie/releases/tag/v6.0.0
+[5.2.0]: https://github.com/upkie/upkie/releases/tag/v5.2.0
+[5.1.0]: https://github.com/upkie/upkie/releases/tag/v5.1.0
+[5.0.1]: https://github.com/upkie/upkie/releases/tag/v5.0.1
+[5.0.0]: https://github.com/upkie/upkie/releases/tag/v5.0.0
+[4.0.0]: https://github.com/upkie/upkie/releases/tag/v4.0.0
+[3.4.0]: https://github.com/upkie/upkie/releases/tag/v3.4.0
+[3.3.0]: https://github.com/upkie/upkie/releases/tag/v3.3.0
+[3.2.0]: https://github.com/upkie/upkie/releases/tag/v3.2.0
+[3.1.0]: https://github.com/upkie/upkie/releases/tag/v3.1.0
+[3.0.0]: https://github.com/upkie/upkie/releases/tag/v3.0.0
+[2.0.0]: https://github.com/upkie/upkie/releases/tag/v2.0.0
+[1.5.0]: https://github.com/upkie/upkie/releases/tag/v1.5.0
+[1.4.0]: https://github.com/upkie/upkie/releases/tag/v1.4.0
+[1.3.4]: https://github.com/upkie/upkie/releases/tag/v1.3.4
+[1.3.3]: https://github.com/upkie/upkie/releases/tag/v1.3.3
+[1.3.2]: https://github.com/upkie/upkie/releases/tag/v1.3.2
+[1.3.1]: https://github.com/upkie/upkie/releases/tag/v1.3.1
+[1.3.0]: https://github.com/upkie/upkie/releases/tag/v1.3.0
+[1.2.1]: https://github.com/upkie/upkie/releases/tag/v1.2.1
+[1.2.0]: https://github.com/upkie/upkie/releases/tag/v1.2.0
+[1.1.0]: https://github.com/upkie/upkie/releases/tag/v1.1.0
+[1.0.0]: https://github.com/upkie/upkie/releases/tag/v1.0.0
+[0.5.0]: https://github.com/upkie/upkie/releases/tag/v0.5.0
+[0.4.0]: https://github.com/upkie/upkie/releases/tag/v0.4.0
+[0.3.1]: https://github.com/upkie/upkie/releases/tag/v0.3.1
+[0.3.0]: https://github.com/upkie/upkie/releases/tag/v0.3.0
+[0.2.0]: https://github.com/upkie/upkie/releases/tag/v0.2.0
 [0.1.0]: https://github.com/upkie/upkie/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "Upkie open source wheeled biped robot"
-version: 10.1.0
-date-released: 2026-03-11
+version: 11.0.0
+date-released: 2026-04-07
 url: "https://github.com/upkie/upkie"
 license: "Apache-2.0"
 authors:

--- a/NOTICE
+++ b/NOTICE
@@ -7,3 +7,4 @@ This project includes contributions made under the following copyrights:
 - Copyright 2022 Stéphane Caron
 - Copyright 2023-2026 Inria
 - Copyright 2026 Stéphane Caron
+- Copyright 2026 CNRS

--- a/README.md
+++ b/README.md
@@ -18,37 +18,37 @@ Upkies come with [step by step build instructions](https://github.com/upkie/upki
 
 ## Getting started
 
-Upkies come with a model predictive controller that can balance and roam around. You can try it out in simulation by:
+Upkies come out-of-the-box with balancing and locomotion capabilities. You can try them out in simulation using [pixi](https://pixi.prefix.dev/):
+
+<img src="https://raw.githubusercontent.com/upkie/upkie/refs/heads/main/docs/images/bullet-spine.png" height="100" align="right" />
 
 ```console
-./start_mpc_balancer.sh
+pixi run example-follow-joystick
+```
+
+Or using [uv](https://docs.astral.sh/uv/):
+
+```console
+uv run examples/follow_joystick.py
 ```
 
 Once the agent is running, you can direct your Upkie using a gamepad 🎮
 
-- **Left joystick:** go forward right backward
-- **Right joystick:** turn left or right
-- **Directional pad:** down to crouch, up to stand up
-- **Right button:** (B on an Xbox controller, red circle on a PS4 controller) emergency stop 🚨 all motors will turn off
+- **Left joystick ⬆️ ⬇️:** go forward or backward
+- **Left joystick ⬅️  ➡️:** turn left or right
+- **Right button:** (B on an Xbox controller, red circle on a PS4 controller) emergency stop 🚨
 
 Click on the robot in the simulator window to apply external forces and see how the robot reacts.
 
 ## Creating your own behaviors
 
-Software for Upkies comes is packaged in an `upkie` Python library. You can install it:
-
-- From conda-forge: `conda install -c conda-forge upkie`
-- From PyPI: `pip install upkie`
-
-When running on the real robot, your code will command the robot's actuators via another process called the *spine*. There are also simulation spines for testing before deploying to a robot. Let's start a Bullet simulation spine:
-
-<img src="https://raw.githubusercontent.com/upkie/upkie/refs/heads/main/docs/images/bullet-spine.png" height="100" align="right" />
+Software for Upkies comes is packaged in an `upkie` Python library that you can install from `conda` or `pip`:
 
 ```console
-./start_simulation.sh
+pip install upkie
 ```
 
-Now that we have a spine is running, we can control the robot in Python. For example:
+This library provides [Gymnasium environments](https://upkie.github.io/upkie/gym-environments.html) to control real and simulation robots with the same code. For instance, the following example balances the robot like a wheeled inverted pendulum in PyBullet:
 
 ```python
 import gymnasium as gym
@@ -57,7 +57,7 @@ import upkie.envs
 
 upkie.envs.register()
 
-with gym.make("Upkie-Spine-Pendulum", frequency=200.0) as env:
+with gym.make("Upkie-PyBullet-Pendulum", frequency=200.0) as env:
     observation, _ = env.reset()
     gain = np.array([10.0, 1.0, 0.0, 0.1])
     for step in range(1_000_000):
@@ -67,11 +67,9 @@ with gym.make("Upkie-Spine-Pendulum", frequency=200.0) as env:
             observation, _ = env.reset()
 ```
 
-Other Gymnasium environments provide various levels of absraction to control the robot. They are listed in the [Gym environments](https://upkie.github.io/upkie/gym-environments.html) page of the documentation.
+To switch to the real robot, replace "PyBullet" by "Spine" in the environment name.
 
-## Going further
-
-### Examples
+## Examples
 
 There are smaller standalone examples in the [examples](https://github.com/upkie/upkie/tree/main/examples) directory. For instance:
 
@@ -80,31 +78,7 @@ There are smaller standalone examples in the [examples](https://github.com/upkie
 - Model predictive control: a self-contained MPC balancer
 - PD balancer: balance by proportional-derivative feedback to wheel velocities.
 
-Some examples have optional dependencies, like those for the Genesis and PyBullet simulators. You can activate a virtual environment and install them as optional dependencies, or use Pixi:
-
-```console
-pixi run --environment genesis ./examples/genesis_balancing.py
-```
-
-### Tasks
-
-Upkies come with a set of default behaviors that you can executed as Pixi tasks. To get started, make sure you have [installed `pixi`](https://pixi.sh/latest/#installation).
-
-| Name                    | Task                                                     |
-|-------------------------|----------------------------------------------------------|
-| `mpc-balancer`          | Run the MPC balancer with a running spine / real robot   |
-| `mpc-balancer-genesis`  | Run the MPC balancer in Genesis                          |
-| `mpc-balancer-pybullet` | Run the MPC balancer in PyBullet                         |
-
-You can execute a task by `pixi run <task-name>`, for instance:
-
-```console
-pixi run mpc-balancer-pybullet
-```
-
-Tasks are available both on your machine and on your Upkie's Raspberry Pi (Pixi comes pre-installed on the SD card image). They are implemented by [agents](https://github.com/upkie/upkie/tree/main/agents). You can make your own agents by forking this repository or using the [new\_agent](https://github.com/upkie/new_agent) template to get started.
-
-### Contributing
+## Contributing
 
 Contributions are welcome to both the hardware and software of Upkies! Check out the [contribution guidelines](CONTRIBUTING.md).
 
@@ -118,7 +92,7 @@ If you built an Upkie or use parts of this project in your works, please cite th
   author = {Caron, St\'{e}phane and Perrin-Gilbert, Nicolas and Ledoux, Viviane and G\"{o}kbakan, \"{U}mit Bora and Raverdy, Pierre-Guillaume and Raffin, Antonin and Tordjman{-}{-}Levavasseur, Valentin and Arlaud, Etienne and Duclusaud, Marc},
   url = {https://github.com/upkie/upkie},
   license = {Apache-2.0},
-  version = {10.1.0},
+  version = {11.0.0},
   year = {2026}
 }
 ```

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = upkie
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 10.1.0
+PROJECT_NUMBER         = 11.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/follow_joystick.py
+++ b/examples/follow_joystick.py
@@ -15,7 +15,7 @@ import gymnasium as gym
 import numpy as np
 
 import upkie.envs
-from upkie.controllers import JoystickGyropodController
+from upkie.controllers import JoystickController
 from upkie.utils.clamp import clamp
 
 upkie.envs.register()
@@ -27,7 +27,7 @@ def main(
     turning_gain_scale: float = 2.0,
 ) -> None:
     gain_scale = clamp(gain_scale, 0.1, 2.0)
-    joystick_controller = JoystickGyropodController()
+    joystick_controller = JoystickController()
     turning_gain_scale = clamp(turning_gain_scale, 0.0, 3.0)
 
     with gym.make(

--- a/examples/real_robot/follow_joystick.py
+++ b/examples/real_robot/follow_joystick.py
@@ -8,7 +8,7 @@ import numpy as np
 import upkie_description
 
 import upkie.envs
-from upkie.controllers import JoystickGyropodController
+from upkie.controllers import JoystickController
 from upkie.logging import logger
 from upkie.model import Model
 from upkie.utils.clamp import clamp
@@ -20,8 +20,8 @@ class Controller:
     """
 
     ## \var joystick_controller
-    ## Joystick controller for gyropod.
-    joystick_controller: JoystickGyropodController
+    ## Joystick controller.
+    joystick_controller: JoystickController
 
     ## \var model
     ## Robot model.
@@ -48,7 +48,7 @@ class Controller:
         \param turning_gain_scale Additional gain scaling applied when turning.
         """
         self.gain_scale = clamp(gain_scale, 0.1, 2.0)
-        self.joystick_controller = JoystickGyropodController()
+        self.joystick_controller = JoystickController()
         self.leg_length = leg_length
         self.max_ground_accel = max_ground_accel
         self.max_ground_velocity = max_ground_velocity

--- a/upkie/__init__.py
+++ b/upkie/__init__.py
@@ -7,7 +7,7 @@
 
 from . import envs, model, utils
 
-__version__ = "10.1.0"
+__version__ = "11.0.0"
 
 __all__ = [
     "envs",

--- a/upkie/controllers/__init__.py
+++ b/upkie/controllers/__init__.py
@@ -6,10 +6,10 @@
 ## \namespace upkie.controllers
 ## \brief Functions and classes related to balance control.
 
-from .joystick_gyropod_controller import JoystickGyropodController
+from .joystick_controller import JoystickController
 from .mpc_balancer import MPCBalancer
 
 __all__ = [
-    "JoystickGyropodController",
+    "JoystickController",
     "MPCBalancer",
 ]

--- a/upkie/controllers/joystick_controller.py
+++ b/upkie/controllers/joystick_controller.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Joystick controller for gyropod."""
+"""Joystick controller."""
 
 from typing import Literal
 
@@ -13,9 +13,9 @@ from upkie.utils.clamp import clamp, clamp_abs
 from upkie.utils.filters import abs_bounded_derivative_filter
 
 
-class JoystickGyropodController:
+class JoystickController:
     r"""!
-    Joystick controller for gyropod.
+    Controller that maps joystick inputs to linear and angular velocities.
     """
 
     ## \var max_linear_accel

--- a/upkie/cpp/version.h
+++ b/upkie/cpp/version.h
@@ -13,6 +13,6 @@
 namespace upkie::cpp {
 
 //! Software version number.
-constexpr std::string_view kVersion = "10.1.0";
+constexpr std::string_view kVersion = "11.0.0";
 
 }  // namespace upkie::cpp


### PR DESCRIPTION
This release adds a switch between Upkie and [Cookie](https://github.com/orgs/upkie/discussions/545) wheeled bipeds, and generalizes the internals to handle both robot models seamlessly. It also adds two Gymnasium environments:

- `UpkieGyropod`: a generalization of `UpkiePendulum` adding yaw orientation to the observation and yaw velocity to the action.
- `UpkieBaseVelocity`: where the Upkie balances by itself, the observation is a (position, yaw) vector in $SE(2)$ and the action is (linear, angular) velocity vector in $\mathfrak{se}(2)$.

Examples now include following joystick commands with a base-velocity environment (replacing the former mpc_balancer agent), and going forward with a pendulum environment.

### Added

- CICD: Add optional pre-commit checks
- CICD: Add unit tests for the Python `Joystick` class
- CICD: Test joystick usage in the PyBullet backend.
- config: Allow both .yaml and .yml file extensions
- controllers: Add `JoystickController` mapping joystick inputs to linear-angular velocities
- controllers: Add `reset` function to `MPCBalancer`
- controllers: Rename MPCBalancer stepping function to `step`
- envs: Add `UpkieBaseVelocity` environment
- envs: Add `UpkieGyropod` environment
- envs: Connect to joystick if available in the PyBullet backend.
- envs: Register `*-*-BaseVelocity` environments
- envs: Register `*-*-Gyropod` environments
- envs: Register `Cookie-*-*` environments
- examples: Follow a square patterrn using a base-velocity environment
- examples: Follow joystick inputs mapped to a base-velocity environment
- model: Add `CollisionGeometry` dataclass
- model: Add `JointProperties` class for per-joint simulation properties
- model: Add `KinematicTree` class for URDF processing
- model: Add `Link` dataclass
- model: Add `Model.left_wheeled` property parsed from URDF
- model: Add `Model.wheel_base` property
- model: Add link properties to `Joint` class
- model: Add small `SE3` class to manipulate transforms
- model: Read orientation of the IMU frame in the base frame from URDF
- model: Read wheel radius from URDF
- utils: Add `skew` to rotation utility functions

### Changed

- **Breaking:** envs: Pendulum environments read `left_wheeled` from the model rather than as a keyword argument
- **Breaking:** envs: Replace `bullet_config` dict in PyBullet backend with explicit `inertia_variation`, `joint_properties`, `torque_control_kd` and `torque_control_kp` kwargs
- Move `start_simulation.sh` to `spines/start_bullet_spine.sh`
- Transfer copyright notices to `NOTICE` file
- envs: Default maximum ground velocity of pendulum environments is now 3 m/s
- envs: Floor contact detection in PyBullet backend now queries wheel-tire contacts with the ground plane
- envs: Set `terminated` and `truncated` when joystick A/cross button is pressed
- examples: Move PyBullet PD balancing example to pybullet/ sub-directory
- logs: Move template log Makefile to tools/
- model: Derive `Model.wheel_base` from robot descriptions
- model: Derive `Model.wheel_radius` from robot descriptions
- model: Move URDF processing to `KinematicTree` class
- mpc_balancer: Merge `RemoteControl` parameters into the new `JoystickController`
- mpc_balancer: Merge `WheelController` into `Controller` class
- mpc_balancer: Moved to `examples/real_robot/follow_joystick.py`
- mpc_balancer: Use left rather than right joystick's left-right axis for yaw control

### Fixed

- CICD: Run both C++ and Python unit tests in `pixi run test`
- cpp: Clean up unused `reset_joint_properties` function
- cpp: Remove joint properties from Bullet interface
- docs: Clean up obsolete Doxygen configuration parameters
- utils: Handle directional pad (D-pad) inputs in `Joystick` class

### Removed

- **Breaking:** Remove `upkie.config` submodule entirely
- Remove `start_mpc_balancer.sh` as there are simpler examples now
- config: Move spine configuration to the spine backend
- config: Remove IMU-to-base rotation from configuration
- config: Remove `wheel_radius` as it is now a property of `Model` and parsed from the URDF collision geometry
- config: Remove robot configuration dictionary as it has become unused
- cpp: Remove unused `follower_camera` parameter from the Bullet interface
- examples: Remove PI balancing variant from real-robot examples
- mpc_balancer: Remove `RemoteControl` class as it is now in `JoystickController`
- mpc_balancer: Remove `WheelController` class as it is now in the `UpkieGyropod` environment