### PR TITLE
Set base orientation from robot model in spine configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CICD: Add C++ formatter call to pre-commit hooks
 - Expose rotation from base to world frame in the PyBullet backend
+- envs: Set base orientation from robot model in spine configuration
 
 ### Fixed
 

--- a/upkie/envs/backends/spine_backend.py
+++ b/upkie/envs/backends/spine_backend.py
@@ -150,6 +150,12 @@ class SpineBackend(Backend):
             "right_wheel": -signed_radius,
         }
 
+        # Set base orientation from robot model so the spine's
+        # BaseOrientation observer uses the correct IMU mounting rotation
+        merged_spine_config["base_orientation"] = {
+            "rotation_base_to_imu": model.rotation_base_to_imu.flatten(),
+        }
+
         # Instance attributes
         self._spine = SpineInterface(shm_name, retries=10)
         self._spine_config = merged_spine_config


### PR DESCRIPTION
This PR passes `model.rotation_base_to_imu` in the spine configuration sent on reset, so the C++ `BaseOrientation` observer uses the correct IMU mounting rotation for the connected robot model.

## Motivation

The C++ `BaseOrientation` observer defaults to `rotation_base_to_imu = diag(-1, 1, -1)` (the pi3hat mounting orientation on the standard Upkie). This default is hardcoded in `BaseOrientation::Parameters::configure()` and applied on every spine reset. For robots with a different IMU mounting, this causes the spine to report an incorrect base orientation.

The `BaseOrientation` observer already supports runtime configuration of `rotation_base_to_imu` via the config dictionary (under `"base_orientation"."rotation_base_to_imu"`), but `SpineBackend` was not sending it.

## Change

In `SpineBackend.__init__()`, add `model.rotation_base_to_imu` (flattened to a 9-element row-major array for palimpsest `Matrix3d` deserialization) to the spine config under `"base_orientation"`.

This is consistent with how `SpineBackend` already derives `wheel_odometry.signed_radius` from the model.